### PR TITLE
Fikset case sensitive db.

### DIFF
--- a/prosessering-jdbc/src/main/kotlin/no/nav/familie/prosessering/domene/Task.kt
+++ b/prosessering-jdbc/src/main/kotlin/no/nav/familie/prosessering/domene/Task.kt
@@ -25,7 +25,11 @@ data class Task(
         override val triggerTid: LocalDateTime = LocalDateTime.now(),
         override val type: String,
         @Column("metadata")
-        val metadataWrapper: PropertiesWrapper = PropertiesWrapper(),
+        val metadataWrapper: PropertiesWrapper = PropertiesWrapper(Properties().apply {
+            this[MDCConstants.MDC_CALL_ID] =
+                    MDC.get(MDCConstants.MDC_CALL_ID)
+                    ?: IdUtils.generateId()
+        }),
         @Version
         override val versjon: Long = 0,
         @MappedCollection(idColumn = "task_id")

--- a/prosessering-jdbc/src/main/kotlin/no/nav/familie/prosessering/domene/Task.kt
+++ b/prosessering-jdbc/src/main/kotlin/no/nav/familie/prosessering/domene/Task.kt
@@ -14,7 +14,7 @@ import java.io.IOException
 import java.time.LocalDateTime
 import java.util.*
 
-@Table("TASK")
+@Table("task")
 data class Task(
         @Id
         override val id: Long = 0L,
@@ -24,11 +24,11 @@ data class Task(
         override val opprettetTid: LocalDateTime = LocalDateTime.now(),
         override val triggerTid: LocalDateTime = LocalDateTime.now(),
         override val type: String,
-        @Column("METADATA")
+        @Column("metadata")
         val metadataWrapper: PropertiesWrapper = PropertiesWrapper(),
         @Version
         override val versjon: Long = 0,
-        @MappedCollection(idColumn = "TASK_ID")
+        @MappedCollection(idColumn = "task_id")
         override val logg: Set<TaskLogg> = setOf(TaskLogg(type = Loggtype.UBEHANDLET))
 ) : ITask() {
 

--- a/prosessering-jdbc/src/main/kotlin/no/nav/familie/prosessering/domene/TaskLogg.kt
+++ b/prosessering-jdbc/src/main/kotlin/no/nav/familie/prosessering/domene/TaskLogg.kt
@@ -4,7 +4,7 @@ import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table
 import java.time.LocalDateTime
 
-@Table("TASK_LOGG")
+@Table("task_logg")
 data class TaskLogg(@Id
                     override val id: Long = 0L,
                     override val endretAv: String = BRUKERNAVN_NÅR_SIKKERHETSKONTEKST_IKKE_FINNES,

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/TestAppConfig.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/TestAppConfig.kt
@@ -2,17 +2,28 @@ package no.nav.familie.prosessering
 
 import no.nav.security.token.support.core.context.TokenValidationContext
 import no.nav.security.token.support.core.context.TokenValidationContextHolder
+import org.h2.jdbcx.JdbcDataSource
 import org.springframework.boot.SpringBootConfiguration
+import org.springframework.boot.jdbc.DatabaseDriver
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories
 import org.springframework.data.jdbc.repository.config.JdbcRepositoryConfigExtension
+import javax.sql.DataSource
 
 @SpringBootConfiguration
 @EnableJdbcRepositories("no.nav.familie")
 @ComponentScan("no.nav.familie")
 class TestAppConfig : JdbcRepositoryConfigExtension() {
 
+//    @Bean
+//    fun dataSource(): DataSource {
+//
+//        return JdbcDataSource().apply {
+//            this.setUrl("jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;CASE_INSENSITIVE_IDENTIFIERS=TRUE;MODE=POSTGRESQL;DB_CLOSE_ON_EXIT=FALSE")
+//        }
+//    }
 
     @Bean
     fun tokenValidationContextHolder(): TokenValidationContextHolder {

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/TestAppConfig.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/TestAppConfig.kt
@@ -2,28 +2,16 @@ package no.nav.familie.prosessering
 
 import no.nav.security.token.support.core.context.TokenValidationContext
 import no.nav.security.token.support.core.context.TokenValidationContextHolder
-import org.h2.jdbcx.JdbcDataSource
 import org.springframework.boot.SpringBootConfiguration
-import org.springframework.boot.jdbc.DatabaseDriver
-import org.springframework.boot.jdbc.EmbeddedDatabaseConnection
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories
 import org.springframework.data.jdbc.repository.config.JdbcRepositoryConfigExtension
-import javax.sql.DataSource
 
 @SpringBootConfiguration
 @EnableJdbcRepositories("no.nav.familie")
 @ComponentScan("no.nav.familie")
 class TestAppConfig : JdbcRepositoryConfigExtension() {
-
-//    @Bean
-//    fun dataSource(): DataSource {
-//
-//        return JdbcDataSource().apply {
-//            this.setUrl("jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;CASE_INSENSITIVE_IDENTIFIERS=TRUE;MODE=POSTGRESQL;DB_CLOSE_ON_EXIT=FALSE")
-//        }
-//    }
 
     @Bean
     fun tokenValidationContextHolder(): TokenValidationContextHolder {

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/AsyncTaskStepTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/AsyncTaskStepTest.kt
@@ -7,7 +7,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.aop.framework.AopProxyUtils
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
 import org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration
 import org.springframework.core.annotation.AnnotationUtils

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/AsyncTaskStepTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/AsyncTaskStepTest.kt
@@ -7,12 +7,14 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.aop.framework.AopProxyUtils
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
+import org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration
 import org.springframework.core.annotation.AnnotationUtils
 import org.springframework.test.context.junit4.SpringRunner
 
 @RunWith(SpringRunner::class)
-@DataJdbcTest
+@DataJdbcTest(excludeAutoConfiguration = [TestDatabaseAutoConfiguration::class])
 class AsyncTaskStepTest {
 
     @Autowired

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/ScheduledTasksServiceTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/ScheduledTasksServiceTest.kt
@@ -9,7 +9,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
+import org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ContextConfiguration
@@ -18,7 +20,7 @@ import org.springframework.test.context.junit4.SpringRunner
 
 @RunWith(SpringRunner::class)
 @ContextConfiguration(classes = [TestAppConfig::class])
-@DataJdbcTest
+@DataJdbcTest(excludeAutoConfiguration = [TestDatabaseAutoConfiguration::class])
 class ScheduledTasksServiceTest {
 
 

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/ScheduledTasksServiceTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/ScheduledTasksServiceTest.kt
@@ -6,10 +6,10 @@ import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
 import org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration
 import org.springframework.data.repository.findByIdOrNull
@@ -29,6 +29,11 @@ class ScheduledTasksServiceTest {
 
     @Autowired
     private lateinit var taskRepository: TaskRepository
+
+    @After
+    fun clear() {
+        taskRepository.deleteAll()
+    }
 
     @Test
     @Sql("classpath:sql-testdata/gamle_tasker_med_logg.sql")
@@ -67,7 +72,6 @@ class ScheduledTasksServiceTest {
 
         assertThat(taskRepository.findByIdOrNull(saved.id)!!.status).isEqualTo(Status.KLAR_TIL_PLUKK)
     }
-
 
 
 }

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskRepositoryTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskRepositoryTest.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.prosessering.internal
 
-import no.nav.familie.log.mdc.MDCConstants
 import no.nav.familie.prosessering.TestAppConfig
 import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
@@ -8,6 +7,7 @@ import no.nav.familie.prosessering.domene.TaskRepository
 import no.nav.familie.prosessering.task.TaskStep1
 import no.nav.familie.prosessering.task.TaskStep2
 import org.assertj.core.api.Assertions
+import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -27,6 +27,10 @@ class TaskRepositoryTest {
     @Autowired
     private lateinit var repository: TaskRepository
 
+    @After
+    fun clear() {
+        repository.deleteAll()
+    }
 
     @Test
     fun `finnTasksMedStatus - skal hente ut alle tasker uavhengig av status`() {

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskRepositoryTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskRepositoryTest.kt
@@ -12,6 +12,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
+import org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.test.context.ContextConfiguration
@@ -20,7 +21,7 @@ import java.util.*
 
 @RunWith(SpringRunner::class)
 @ContextConfiguration(classes = [TestAppConfig::class])
-@DataJdbcTest
+@DataJdbcTest(excludeAutoConfiguration = [TestDatabaseAutoConfiguration::class])
 class TaskRepositoryTest {
 
     @Autowired

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorServiceTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorServiceTest.kt
@@ -16,6 +16,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
+import org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.junit4.SpringRunner
@@ -23,7 +24,7 @@ import org.springframework.test.context.transaction.TestTransaction
 
 @RunWith(SpringRunner::class)
 @ContextConfiguration(classes = [TestAppConfig::class])
-@DataJdbcTest
+@DataJdbcTest(excludeAutoConfiguration = [TestDatabaseAutoConfiguration::class])
 class TaskStepExecutorServiceTest {
 
     @Autowired
@@ -79,6 +80,7 @@ class TaskStepExecutorServiceTest {
             launch.join()
             launch2.join()
         }
+
         val findAll = repository.findAll()
         findAll.filter { it.status != Status.FERDIG || it.logg.size > 4 }.forEach {
             assertThat(it.status).isEqualTo(Status.FERDIG)

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorServiceTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorServiceTest.kt
@@ -12,6 +12,7 @@ import no.nav.familie.prosessering.domene.TaskRepository
 import no.nav.familie.prosessering.task.TaskStep2
 import no.nav.familie.prosessering.task.TaskStepFeilManuellOppfølgning
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -36,8 +37,10 @@ class TaskStepExecutorServiceTest {
     @Autowired
     private lateinit var taskStepExecutorService: TaskStepExecutorService
 
-    @Autowired
-    private lateinit var scheduledTasksService: ScheduledTaskService
+    @After
+    fun clear() {
+        repository.deleteAll()
+    }
 
     @Test
     fun `skal håndtere feil`() {

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskWorkerTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskWorkerTest.kt
@@ -10,6 +10,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
+import org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.junit4.SpringRunner
@@ -17,7 +18,7 @@ import org.springframework.test.context.transaction.TestTransaction
 
 @RunWith(SpringRunner::class)
 @ContextConfiguration(classes = [TestAppConfig::class])
-@DataJdbcTest
+@DataJdbcTest(excludeAutoConfiguration = [TestDatabaseAutoConfiguration::class])
 class TaskWorkerTest {
 
     @Autowired

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskWorkerTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskWorkerTest.kt
@@ -6,6 +6,7 @@ import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
 import no.nav.familie.prosessering.task.TaskStep1
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -26,6 +27,11 @@ class TaskWorkerTest {
 
     @Autowired
     private lateinit var worker: TaskWorker
+
+    @After
+    fun clear() {
+        repository.deleteAll()
+    }
 
     @Test
     fun `skal behandle task`() {

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerIntegrasjonTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerIntegrasjonTest.kt
@@ -9,6 +9,7 @@ import no.nav.familie.prosessering.domene.TaskRepository
 import no.nav.familie.prosessering.task.TaskStep1
 import no.nav.familie.prosessering.task.TaskStep2
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -26,10 +27,16 @@ internal class TaskControllerIntegrasjonTest {
 
     @Autowired
     lateinit var restTaskService: RestTaskService
+
     @Autowired
     lateinit var repository: TaskRepository
 
     lateinit var taskController: TaskController
+
+    @After
+    fun clear() {
+        repository.deleteAll()
+    }
 
     @Before
     fun setup() {

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerIntegrasjonTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerIntegrasjonTest.kt
@@ -14,13 +14,14 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
+import org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.junit4.SpringRunner
 
 @RunWith(SpringRunner::class)
 @ContextConfiguration(classes = [TestAppConfig::class])
-@DataJdbcTest
+@DataJdbcTest(excludeAutoConfiguration = [TestDatabaseAutoConfiguration::class])
 internal class TaskControllerIntegrasjonTest {
 
     @Autowired

--- a/prosessering-jdbc/src/test/resources/application.yaml
+++ b/prosessering-jdbc/src/test/resources/application.yaml
@@ -20,7 +20,7 @@ spring:
 
 
     hikari:
-      maximum-pool-size: 2
+      maximum-pool-size: 4
       connection-test-query: "select 1"
       max-lifetime: 30000
       minimum-idle: 1

--- a/prosessering-jpa/src/main/kotlin/no/nav/familie/prosessering/domene/Task.kt
+++ b/prosessering-jpa/src/main/kotlin/no/nav/familie/prosessering/domene/Task.kt
@@ -25,7 +25,11 @@ data class Task(
         override val triggerTid: LocalDateTime = LocalDateTime.now(),
         override val type: String,
         @Convert(converter = PropertiesToStringConverter::class)
-        override val metadata: Properties = Properties(),
+        override val metadata: Properties = Properties().apply {
+            this[MDCConstants.MDC_CALL_ID] =
+                    MDC.get(MDCConstants.MDC_CALL_ID)
+                    ?: IdUtils.generateId()
+        },
         @Version
         override val versjon: Long = 0,
         // Setter fetch til eager fordi AsyncTask ikke får lastet disse hvis ikke den er prelastet.


### PR DESCRIPTION
Testbasen var case-sensitiv, og krevde store bokstaver på spesifiserte tabell og kolonnenavn. Postgress har alt i små bokstaver, så den taklet ikke store bokstaver når biblioteket ble tatt i bruk.