### PR TITLE
Endret til å ikke logge hele task/taskLogg, samt bedre håntering av O…

### DIFF
--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorService.kt
@@ -3,6 +3,7 @@ package no.nav.familie.prosessering.internal
 import no.nav.familie.log.mdc.MDCConstants
 import no.nav.familie.prosessering.domene.ITask
 import no.nav.familie.prosessering.error.RekjørSenereException
+import no.nav.familie.prosessering.util.isOptimisticLocking
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Qualifier
@@ -49,8 +50,13 @@ class TaskStepExecutorService(@Value("\${prosessering.maxAntall:10}") private va
 
         val plukketTask = try {
             taskWorker.markerPlukket(task.id) ?: return
-        } catch (e: OptimisticLockingFailureException) {
-            log.info("OptimisticLockingFailureException for task ${task.id}")
+        } catch (e: Exception) {
+            if(isOptimisticLocking(e)) {
+                log.info("OptimisticLockingFailureException metode=executeWork for task=${task.id}")
+            } else {
+                log.error("Feilet metode=executeWork task=${task.id}. Se secure logs")
+                secureLog.info("Feilet metode=executeWork task=${task.id}", e)
+            }
             return
         }
 

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/util/OptimisticLockingUtil.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/util/OptimisticLockingUtil.kt
@@ -1,0 +1,6 @@
+package no.nav.familie.prosessering.util
+
+import org.springframework.dao.OptimisticLockingFailureException
+
+inline fun isOptimisticLocking(e: Exception): Boolean =
+        e is OptimisticLockingFailureException || e.cause is OptimisticLockingFailureException

--- a/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/util/OptimisticLockingUtilTest.kt
+++ b/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/util/OptimisticLockingUtilTest.kt
@@ -1,0 +1,18 @@
+package no.nav.familie.prosessering.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.dao.OptimisticLockingFailureException
+
+internal class OptimisticLockingUtilTest {
+
+    @Test
+    internal fun `skal sjekke om exception eller cause er OptimisticLockingFailureException`() {
+        assertThat(isOptimisticLocking(RuntimeException(OptimisticLockingFailureException("")))).isTrue
+        assertThat(isOptimisticLocking(OptimisticLockingFailureException(""))).isTrue
+
+        assertThat(isOptimisticLocking(RuntimeException("asd"))).isFalse
+        assertThat(isOptimisticLocking(RuntimeException(RuntimeException("")))).isFalse
+    }
+
+}

--- a/prosessering-jdbc/src/main/kotlin/no/nav/familie/prosessering/domene/Task.kt
+++ b/prosessering-jdbc/src/main/kotlin/no/nav/familie/prosessering/domene/Task.kt
@@ -36,6 +36,8 @@ data class Task(
         override val logg: Set<TaskLogg> = setOf(TaskLogg(type = Loggtype.UBEHANDLET))
 ) : ITask() {
 
+
+
     @Transient
     override val metadata: Properties = metadataWrapper.properties
 
@@ -95,6 +97,10 @@ data class Task(
 
     override fun medTriggerTid(triggerTid: LocalDateTime): Task {
         return this.copy(triggerTid = triggerTid)
+    }
+
+    override fun toString(): String {
+        return "Task(id=$id, status=$status, opprettetTid=$opprettetTid, triggerTid=$triggerTid, type='$type', versjon=$versjon)"
     }
 
 }

--- a/prosessering-jdbc/src/main/kotlin/no/nav/familie/prosessering/domene/TaskLogg.kt
+++ b/prosessering-jdbc/src/main/kotlin/no/nav/familie/prosessering/domene/TaskLogg.kt
@@ -11,4 +11,9 @@ data class TaskLogg(@Id
                     override val type: Loggtype,
                     override val node: String = "node1",
                     override val melding: String? = null,
-                    override val opprettetTid: LocalDateTime = LocalDateTime.now()) : ITaskLogg()
+                    override val opprettetTid: LocalDateTime = LocalDateTime.now()) : ITaskLogg() {
+
+    override fun toString(): String {
+        return "TaskLogg(id=$id, type=$type, opprettetTid=$opprettetTid)"
+    }
+}

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/domene/TaskTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/domene/TaskTest.kt
@@ -1,0 +1,27 @@
+package no.nav.familie.prosessering.domene
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.Properties
+
+internal class TaskTest {
+
+    private val tid = LocalDateTime.of(2021, 1, 1, 0, 0, 0)
+
+    @Test
+    internal fun `Task skal ikke logge payload eller metadata`() {
+        val task = Task("Type", "payload", Properties().also { it.put("key", "value") })
+                .copy(opprettetTid = tid, triggerTid = tid)
+        assertThat(task.toString())
+                .isEqualTo("Task(id=0, status=UBEHANDLET, opprettetTid=2021-01-01T00:00, triggerTid=2021-01-01T00:00, type='Type', versjon=0)")
+    }
+
+    @Test
+    internal fun `TaskLogg skal ikke logge melding`() {
+        val taskLogg = TaskLogg(melding = "melding", type = Loggtype.FEILET)
+                .copy(opprettetTid = tid)
+        assertThat(taskLogg.toString())
+                .isEqualTo("TaskLogg(id=0, type=FEILET, opprettetTid=2021-01-01T00:00)")
+    }
+}

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskWorkerTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskWorkerTest.kt
@@ -1,5 +1,11 @@
 package no.nav.familie.prosessering.internal
 
+import com.ninjasquad.springmockk.SpykBean
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.justRun
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
 import no.nav.familie.prosessering.TestAppConfig
 import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
@@ -16,13 +22,15 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.context.transaction.TestTransaction
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [TestAppConfig::class])
 @DataJdbcTest(excludeAutoConfiguration = [TestDatabaseAutoConfiguration::class])
 class TaskWorkerTest {
 
-    @Autowired
+    @SpykBean
     private lateinit var repository: TaskRepository
 
     @Autowired
@@ -46,4 +54,37 @@ class TaskWorkerTest {
         assertThat(findByIdOrNull?.logg).hasSize(4)
     }
 
+    @Test
+    internal fun `skal håndtere 2 prosesser som oppdaterer en task`() {
+        val called = AtomicBoolean(false)
+        val task = repository.save(Task(TaskStep1.TASK_1, "{'a'='b'}"))
+        TestTransaction.flagForCommit()
+        TestTransaction.end()
+
+        every { repository.save(any()) } answers {
+            println("Yolo")
+            if(called.compareAndSet(false, true)){
+                println("sleep")
+                Thread.sleep(500)
+                println("sleep done")
+            } else {
+                println("do not sleep")
+            }
+            callOriginal()
+        }
+        runBlocking {
+            val update1 = async {
+                println("1")
+                worker.markerPlukket(task.id)
+                println("1 - done")
+            }
+            val update2 = async {
+                println("2")
+                worker.markerPlukket(task.id)
+                println("2 - done")
+            }
+            update1.await()
+            update2.await()
+        }
+    }
 }

--- a/prosessering-jpa/src/main/kotlin/no/nav/familie/prosessering/domene/Task.kt
+++ b/prosessering-jpa/src/main/kotlin/no/nav/familie/prosessering/domene/Task.kt
@@ -6,8 +6,21 @@ import no.nav.familie.prosessering.TaskFeil
 import org.slf4j.MDC
 import java.io.IOException
 import java.time.LocalDateTime
-import java.util.*
-import javax.persistence.*
+import java.util.Properties
+import javax.persistence.CascadeType
+import javax.persistence.Convert
+import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import javax.persistence.FetchType
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.OneToMany
+import javax.persistence.SequenceGenerator
+import javax.persistence.Table
+import javax.persistence.Version
 
 @Entity
 @Table(name = "TASK")
@@ -99,6 +112,10 @@ data class Task(
 
     override fun medTriggerTid(triggerTid: LocalDateTime): Task {
         return this.copy(triggerTid = triggerTid)
+    }
+
+    override fun toString(): String {
+        return "Task(id=$id, status=$status, opprettetTid=$opprettetTid, triggerTid=$triggerTid, type='$type', versjon=$versjon)"
     }
 
 }

--- a/prosessering-jpa/src/main/kotlin/no/nav/familie/prosessering/domene/TaskLogg.kt
+++ b/prosessering-jpa/src/main/kotlin/no/nav/familie/prosessering/domene/TaskLogg.kt
@@ -1,7 +1,15 @@
 package no.nav.familie.prosessering.domene
 
 import java.time.LocalDateTime
-import javax.persistence.*
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.SequenceGenerator
+import javax.persistence.Table
 
 @Entity
 @Table(name = "TASK_LOGG")
@@ -22,4 +30,9 @@ data class TaskLogg(
         override val melding: String? = null,
 
         override val opprettetTid: LocalDateTime = LocalDateTime.now()
-) : ITaskLogg()
+) : ITaskLogg() {
+
+    override fun toString(): String {
+        return "TaskLogg(id=$id, type=$type, opprettetTid=$opprettetTid)"
+    }
+}

--- a/prosessering-jpa/src/test/kotlin/no/nav/familie/prosessering/domene/TaskTest.kt
+++ b/prosessering-jpa/src/test/kotlin/no/nav/familie/prosessering/domene/TaskTest.kt
@@ -1,0 +1,27 @@
+package no.nav.familie.prosessering.domene
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.Properties
+
+internal class TaskTest {
+
+    private val tid = LocalDateTime.of(2021, 1, 1, 0, 0, 0)
+
+    @Test
+    internal fun `Task skal ikke logge payload eller metadata`() {
+        val task = Task("Type", "payload", Properties().also { it.put("key", "value") })
+                .copy(opprettetTid = tid, triggerTid = tid)
+        assertThat(task.toString())
+                .isEqualTo("Task(id=0, status=UBEHANDLET, opprettetTid=2021-01-01T00:00, triggerTid=2021-01-01T00:00, type='Type', versjon=0)")
+    }
+
+    @Test
+    internal fun `TaskLogg skal ikke logge melding`() {
+        val taskLogg = TaskLogg(melding = "melding", type = Loggtype.FEILET)
+                .copy(opprettetTid = tid)
+        assertThat(taskLogg.toString())
+                .isEqualTo("TaskLogg(id=0, type=FEILET, opprettetTid=2021-01-01T00:00)")
+    }
+}


### PR DESCRIPTION
…ptimisticLockingFailureException

Idag logges hele tasken, og OptimisticLockingFailureException blir ikke håndtert som forventet

Jeg har tenkt å fikse locking-tester senere

```
rg.springframework.data.relational.core.conversion.DbActionExecutionException: Failed to execute DbAction.UpdateRoot(entity=Task(..., logg=[TaskLogg(...]))
	at org.springframework.data.jdbc.core.AggregateChangeExecutor.execute(AggregateChangeExecutor.java:89)
	at org.springframework.data.jdbc.core.AggregateChangeExecutor.lambda$execute$0(AggregateChangeExecutor.java:50)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at org.springframework.data.relational.core.conversion.DefaultAggregateChange.forEachAction(DefaultAggregateChange.java:116)
	at org.springframework.data.jdbc.core.AggregateChangeExecutor.execute(AggregateChangeExecutor.java:50)
	at org.springframework.data.jdbc.core.JdbcAggregateTemplate.store(JdbcAggregateTemplate.java:339)
	at org.springframework.data.jdbc.core.JdbcAggregateTemplate.save(JdbcAggregateTemplate.java:149)
	at org.springframework.data.jdbc.repository.support.SimpleJdbcRepository.save(SimpleJdbcRepository.java:60)
	at jdk.internal.reflect.GeneratedMethodAccessor138.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.data.repository.core.support.RepositoryMethodInvoker$RepositoryFragmentMethodInvoker.lambda$new$0(RepositoryMethodInvoker.java:289)
	at org.springframework.data.repository.core.support.RepositoryMethodInvoker.doInvoke(RepositoryMethodInvoker.java:137)
	at org.springframework.data.repository.core.support.RepositoryMethodInvoker.invoke(RepositoryMethodInvoker.java:121)
	at org.springframework.data.repository.core.support.RepositoryComposition$RepositoryFragments.invoke(RepositoryComposition.java:524)
	at org.springframework.data.repository.core.support.RepositoryComposition.invoke(RepositoryComposition.java:285)
	at org.springframework.data.repository.core.support.RepositoryFactorySupport$ImplementationMethodExecutionInterceptor.invoke(RepositoryFactorySupport.java:531)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.data.repository.core.support.QueryExecutorMethodInterceptor.doInvoke(QueryExecutorMethodInterceptor.java:156)
	at org.springframework.data.repository.core.support.QueryExecutorMethodInterceptor.invoke(QueryExecutorMethodInterceptor.java:131)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:123)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:388)
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.dao.support.PersistenceExceptionTranslationInterceptor.invoke(PersistenceExceptionTranslationInterceptor.java:137)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.data.repository.core.support.MethodInvocationValidator.invoke(MethodInvocationValidator.java:98)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215)
	at com.sun.proxy.$Proxy136.save(Unknown Source)
	at jdk.internal.reflect.GeneratedMethodAccessor137.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.springframework.dao.support.PersistenceExceptionTranslationInterceptor.invoke(PersistenceExceptionTranslationInterceptor.java:137)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215)
	at com.sun.proxy.$Proxy136.save(Unknown Source)
	at no.nav.familie.prosessering.internal.TaskService.save(TaskService.kt:19)
	at no.nav.familie.prosessering.internal.TaskWorker.markerPlukket(TaskWorker.kt:146)
	at no.nav.familie.prosessering.internal.TaskWorker$$FastClassBySpringCGLIB$$746044b1.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:779)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:750)
	at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:123)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:388)
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:750)
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:692)
	at no.nav.familie.prosessering.internal.TaskWorker$$EnhancerBySpringCGLIB$$d12e7f82.markerPlukket(<generated>)
	at no.nav.familie.prosessering.internal.TaskStepExecutorService.executeWork(TaskStepExecutorService.kt:51)
	at no.nav.familie.prosessering.internal.TaskStepExecutorService.pollAndExecute(TaskStepExecutorService.kt:39)
	at jdk.internal.reflect.GeneratedMethodAccessor125.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:84)
	at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: org.springframework.dao.OptimisticLockingFailureException: Optimistic lock exception on saving entity of type no.nav.familie.prosessering.domene.Task.
	at org.springframework.data.jdbc.core.convert.DefaultDataAccessStrategy.updateWithVersion(DefaultDataAccessStrategy.java:175)
	at org.springframework.data.jdbc.core.JdbcAggregateChangeExecutionContext.updateWithVersion(JdbcAggregateChangeExecutionContext.java:387)
	at org.springframework.data.jdbc.core.JdbcAggregateChangeExecutionContext.executeUpdateRoot(JdbcAggregateChangeExecutionContext.java:112)
	at org.springframework.data.jdbc.core.AggregateChangeExecutor.execute(AggregateChangeExecutor.java:70)
	... 69 common frames omitted
```