### PR TITLE
Lagt til optimistic locking håndtering for tasks til sletting

### DIFF
--- a/prosessering-jpa/src/test/kotlin/no/nav/familie/prosessering/internal/ScheduledTasksServiceTest.kt
+++ b/prosessering-jpa/src/test/kotlin/no/nav/familie/prosessering/internal/ScheduledTasksServiceTest.kt
@@ -6,6 +6,7 @@ import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired

--- a/prosessering-jpa/src/test/kotlin/no/nav/familie/prosessering/internal/TaskRepositoryTest.kt
+++ b/prosessering-jpa/src/test/kotlin/no/nav/familie/prosessering/internal/TaskRepositoryTest.kt
@@ -33,15 +33,9 @@ class TaskRepositoryTest {
     private lateinit var repository: TaskRepository
 
     @AfterEach
-    fun clear() {
-        repository.deleteAll()
-    }
-
-    @AfterEach
     fun resetDatabaseInnhold() {
         repository.deleteAll()
     }
-
 
     @Test
     fun `finnTasksMedStatus - skal hente ut alle tasker uavhengig av status`() {

--- a/prosessering-jpa/src/test/kotlin/no/nav/familie/prosessering/internal/TaskRepositoryTest.kt
+++ b/prosessering-jpa/src/test/kotlin/no/nav/familie/prosessering/internal/TaskRepositoryTest.kt
@@ -123,7 +123,6 @@ class TaskRepositoryTest {
         repository.save(task.copy(status = Status.KLAR_TIL_PLUKK))
         TestTransaction.flagForCommit()
         TestTransaction.end()
-        TestTransaction.start()
         assertThat(catchThrowable { repository.save(task.copy(status = Status.KLAR_TIL_PLUKK)) })
                 .matches { isOptimisticLocking(it as Exception) }
     }

--- a/prosessering-jpa/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerIntegrasjonTest.kt
+++ b/prosessering-jpa/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerIntegrasjonTest.kt
@@ -32,11 +32,6 @@ internal class TaskControllerIntegrasjonTest {
 
     lateinit var taskController: TaskController
 
-    @AfterEach
-    fun clear() {
-        repository.deleteAll()
-    }
-
     @BeforeEach
     fun setup() {
         taskController = TaskController(restTaskService, mockk())


### PR DESCRIPTION
Det finens fortsatt en risiko att disse kommer kaste feil når hele transaskjonen commites i en @Scheduled, men virker ikke som att vi har de feilene nå. 
Hvis man skal løse det må man kanskje la `ScheduledTaskService` kun håndtere schedulering og kalle en ny service med @Transactional(propagation = Propagation.REQUIRES_NEW) for hver task. 