### PR TITLE
Trenger ikke å lagre exception for alle typer feil, blir enklere å se…

### DIFF
--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/TaskFeil.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/TaskFeil.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.ObjectReader
 import com.fasterxml.jackson.databind.ObjectWriter
 import no.nav.familie.prosessering.domene.ITask
+import no.nav.familie.prosessering.error.TaskExceptionUtenStackTrace
 import java.io.IOException
 import java.io.PrintWriter
 import java.io.StringWriter
@@ -64,7 +65,7 @@ data class TaskFeil(
         }
 
         private fun getStacktraceAsString(cause: Throwable?): String? {
-            if (cause == null) {
+            if (cause == null || cause is TaskExceptionUtenStackTrace) {
                 return null
             }
             val sw = StringWriter(4096)

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/error/TaskExceptionUtenStackTrace.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/error/TaskExceptionUtenStackTrace.kt
@@ -1,0 +1,3 @@
+package no.nav.familie.prosessering.error
+
+class TaskExceptionUtenStackTrace(melding: String) : RuntimeException(melding)

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/task/TaskStepExceptionUtenStackTrace.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/task/TaskStepExceptionUtenStackTrace.kt
@@ -1,0 +1,27 @@
+package no.nav.familie.prosessering.task
+
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.error.RekjørSenereException
+import no.nav.familie.prosessering.error.TaskExceptionUtenStackTrace
+import org.springframework.stereotype.Service
+import java.lang.RuntimeException
+import java.time.LocalDate
+import java.util.concurrent.TimeUnit
+
+@Service
+@TaskStepBeskrivelse(taskStepType = TaskStepExceptionUtenStackTrace.TYPE, beskrivelse = "")
+class TaskStepExceptionUtenStackTrace : AsyncTaskStep {
+
+    override fun doTask(task: Task) {
+        throw TaskExceptionUtenStackTrace("feilmelding")
+    }
+
+    override fun onCompletion(task: Task) {}
+
+    companion object {
+
+        const val TYPE = "TaskStepExceptionUtenStackTrace"
+    }
+}


### PR DESCRIPTION
… hva som skjedd i loggen i prosessering hvis man ikke trenger å se på 10 stack traces som ikke er nødvendige

Vi har flere tilfeller der vi ikke trenger å ha en lang stack trace når en task feiler, då vi ofte klarer oss med en enkel feilmelding. 