### PR TITLE
Legger til mulighet for å hente og kjøre tasker på nytt direkt etter …

### DIFF
--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/TaskStepBeskrivelse.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/TaskStepBeskrivelse.kt
@@ -30,7 +30,7 @@ annotation class TaskStepBeskrivelse(
         /**
          * Hvor lenge man skal vente ved feil.
          */
-        val triggerTidVedFeilISekunder: Long = 0,
+        val triggerTidVedFeilISekunder: Long = 15,
 
         /**
          * Sett til manuell behandling etter maksAntallFeil

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorService.kt
@@ -81,7 +81,7 @@ class TaskStepExecutorService(@Value("\${prosessering.maxAntall:10}") private va
 
     private fun executeTasks(tasks: List<ITask>): Boolean {
         if (!continuousRunningEnabled) {
-            tasks.forEach { executeWork(it) }
+            tasks.forEach { taskExecutor.execute { executeWork(it) } }
             return false
         }
         val futures = tasks.map { task ->

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorService.kt
@@ -21,11 +21,12 @@ import java.util.concurrent.TimeoutException
 import kotlin.math.min
 
 /**
- * @param [rerunEnabled] hvis true så kjører man tasks direkt på nytt etter att man behandlet tasks
+ * @param [continuousRunningEnabled] hvis true så kjører man tasks direkt på nytt etter att man behandlet tasks
  */
 @Service
 class TaskStepExecutorService(@Value("\${prosessering.maxAntall:10}") private val maxAntall: Int,
-                              @Value("\${prosessering.rerun.enabled:true}") private val rerunEnabled: Boolean,
+                              @Value("\${prosessering.continuousRunning.enabled:false}")
+                              private val continuousRunningEnabled: Boolean,
                               @Value("\${prosessering.fixedDelayString.in.milliseconds:1000}")
                               private val fixedDelayString: String,
                               private val taskWorker: TaskWorker,
@@ -79,7 +80,7 @@ class TaskStepExecutorService(@Value("\${prosessering.maxAntall:10}") private va
     }
 
     private fun executeTasks(tasks: List<ITask>): Boolean {
-        if (!rerunEnabled) {
+        if (!continuousRunningEnabled) {
             tasks.forEach { executeWork(it) }
             return false
         }

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskWorker.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskWorker.kt
@@ -19,9 +19,7 @@ import org.springframework.transaction.annotation.Transactional
 
 @Service
 class TaskWorker(private val taskService: TaskService,
-                 taskStepTyper: List<AsyncITaskStep<out ITask>>,
-                 @Value("\${prosessering.triggertidvedfeilisekunder:15}")
-                 private val triggerTidVedFeilISekunder: Long) {
+                 taskStepTyper: List<AsyncITaskStep<out ITask>>) {
 
     private val taskStepMap: Map<String, AsyncITaskStep<ITask>>
 
@@ -117,7 +115,7 @@ class TaskWorker(private val taskService: TaskService,
     }
 
     private fun finnTriggerTidVedFeil(taskType: String): Long {
-        return triggerTidVedFeilMap[taskType] ?: triggerTidVedFeilISekunder
+        return triggerTidVedFeilMap[taskType] ?: error("Ukjent tasktype $taskType")
     }
 
     private fun finnFeilteller(taskType: String): Counter {

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskWorker.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskWorker.kt
@@ -11,13 +11,17 @@ import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.error.RekjørSenereException
 import org.slf4j.LoggerFactory
 import org.springframework.aop.framework.AopProxyUtils
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.annotation.AnnotationUtils
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 
 @Service
-class TaskWorker(private val taskService: TaskService, taskStepTyper: List<AsyncITaskStep<out ITask>>) {
+class TaskWorker(private val taskService: TaskService,
+                 taskStepTyper: List<AsyncITaskStep<out ITask>>,
+                 @Value("\${prosessering.triggertidvedfeilisekunder:15}")
+                 private val triggerTidVedFeilISekunder: Long) {
 
     private val taskStepMap: Map<String, AsyncITaskStep<ITask>>
 
@@ -113,7 +117,7 @@ class TaskWorker(private val taskService: TaskService, taskStepTyper: List<Async
     }
 
     private fun finnTriggerTidVedFeil(taskType: String): Long {
-        return triggerTidVedFeilMap[taskType] ?: 0
+        return triggerTidVedFeilMap[taskType] ?: triggerTidVedFeilISekunder
     }
 
     private fun finnFeilteller(taskType: String): Counter {

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorServiceTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorServiceTest.kt
@@ -36,7 +36,7 @@ import java.util.UUID
 
 @EnableScheduling
 @ExtendWith(SpringExtension::class)
-@ContextConfiguration(classes = [TestAppConfig::class], )
+@ContextConfiguration(classes = [TestAppConfig::class])
 @DataJdbcTest(excludeAutoConfiguration = [TestDatabaseAutoConfiguration::class])
 class TaskStepExecutorServiceTest {
 

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorServiceWithoutRerunTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorServiceWithoutRerunTest.kt
@@ -38,7 +38,7 @@ import java.util.UUID
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [TestAppConfig::class], )
 @DataJdbcTest(excludeAutoConfiguration = [TestDatabaseAutoConfiguration::class])
-class TaskStepExecutorServiceTest {
+class TaskStepExecutorServiceWithoutRerunTest {
 
     @Autowired
     private lateinit var repository: TaskRepository

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/task/TaskStepMedFeil.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/task/TaskStepMedFeil.kt
@@ -1,0 +1,20 @@
+package no.nav.familie.prosessering.task
+
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import org.springframework.stereotype.Service
+
+@Service
+@TaskStepBeskrivelse(taskStepType = TaskStepMedFeil.TYPE, beskrivelse = "Task med feil")
+class TaskStepMedFeil : AsyncTaskStep {
+
+    override fun doTask(task: Task) {
+        error("Feil")
+    }
+
+    companion object {
+
+        const val TYPE = "taskMedFeil"
+    }
+}

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/task/TaskStepMedFeil.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/task/TaskStepMedFeil.kt
@@ -6,7 +6,8 @@ import no.nav.familie.prosessering.domene.Task
 import org.springframework.stereotype.Service
 
 @Service
-@TaskStepBeskrivelse(taskStepType = TaskStepMedFeil.TYPE, beskrivelse = "Task med feil")
+@TaskStepBeskrivelse(taskStepType = TaskStepMedFeil.TYPE,
+                     beskrivelse = "Task med feil")
 class TaskStepMedFeil : AsyncTaskStep {
 
     override fun doTask(task: Task) {

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/task/TaskStepMedFeilMedTriggerTid0.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/task/TaskStepMedFeilMedTriggerTid0.kt
@@ -6,20 +6,17 @@ import no.nav.familie.prosessering.domene.Task
 import org.springframework.stereotype.Service
 
 @Service
-@TaskStepBeskrivelse(taskStepType = TaskStepFeilManuellOppfølgning.TASK_FEIL_1,
-                     beskrivelse = "Dette er task 1",
-                     settTilManuellOppfølgning = true,
+@TaskStepBeskrivelse(taskStepType = TaskStepMedFeilMedTriggerTid0.TYPE,
+                     beskrivelse = "Task med feil",
                      triggerTidVedFeilISekunder = 0)
-class TaskStepFeilManuellOppfølgning : AsyncTaskStep {
-
+class TaskStepMedFeilMedTriggerTid0 : AsyncTaskStep {
 
     override fun doTask(task: Task) {
-        error("Feiler")
+        error("Feil")
     }
 
     companion object {
 
-        const val TASK_FEIL_1 = "taskFeilManuellOppfølgning1"
+        const val TYPE = "taskMedFeilMedTriggerTid0"
     }
-
 }

--- a/prosessering-jdbc/src/test/resources/application.yaml
+++ b/prosessering-jdbc/src/test/resources/application.yaml
@@ -24,3 +24,5 @@ spring:
       connection-test-query: "select 1"
       max-lifetime: 30000
       minimum-idle: 1
+
+prosessering.continuousRunning.enabled: true

--- a/prosessering-jpa/src/test/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorServiceWithoutContinuousRunningTest.kt
+++ b/prosessering-jpa/src/test/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorServiceWithoutContinuousRunningTest.kt
@@ -1,0 +1,61 @@
+package no.nav.familie.prosessering.internal
+
+import no.nav.familie.prosessering.TestAppConfig
+import no.nav.familie.prosessering.domene.Loggtype
+import no.nav.familie.prosessering.domene.Status
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.domene.TaskRepository
+import no.nav.familie.prosessering.task.TaskStepMedFeilMedTriggerTid0
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.context.transaction.TestTransaction
+
+@ExtendWith(SpringExtension::class)
+@ContextConfiguration(classes = [TestAppConfig::class])
+@DataJpaTest(excludeAutoConfiguration = [FlywayAutoConfiguration::class],
+             properties = ["prosessering.continuousRunning.enabled=false"])
+class TaskStepExecutorServiceWithoutContinuousRunningTest {
+
+    @Autowired
+    private lateinit var repository: TaskRepository
+
+    @Autowired
+    private lateinit var taskStepExecutorService: TaskStepExecutorService
+
+    @AfterEach
+    fun clear() {
+        repository.deleteAll()
+    }
+
+    @Test
+    fun `skal håndtere feil i en ny schedulering med continuousRunning=false`() {
+        var savedTask = Task(TaskStepMedFeilMedTriggerTid0.TYPE, "{'a'='b'}")
+        repository.save(savedTask)
+        TestTransaction.flagForCommit()
+        TestTransaction.end()
+
+        assertThat(savedTask.status).isEqualTo(Status.UBEHANDLET)
+
+        taskStepExecutorService.pollAndExecute()
+        savedTask = repository.findById(savedTask.id).orElseThrow()
+        assertThat(savedTask.status).isEqualTo(Status.KLAR_TIL_PLUKK)
+
+        taskStepExecutorService.pollAndExecute()
+        savedTask = repository.findById(savedTask.id).orElseThrow()
+        assertThat(savedTask.status).isEqualTo(Status.KLAR_TIL_PLUKK)
+
+        taskStepExecutorService.pollAndExecute()
+        savedTask = repository.findById(savedTask.id).orElseThrow()
+        assertThat(savedTask.status).isEqualTo(Status.FEILET)
+
+        assertThat(savedTask.logg.filter { it.type == Loggtype.FEILET }).hasSize(3)
+    }
+
+}

--- a/prosessering-jpa/src/test/kotlin/no/nav/familie/prosessering/task/TaskStepMedFeil.kt
+++ b/prosessering-jpa/src/test/kotlin/no/nav/familie/prosessering/task/TaskStepMedFeil.kt
@@ -1,0 +1,20 @@
+package no.nav.familie.prosessering.task
+
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import org.springframework.stereotype.Service
+
+@Service
+@TaskStepBeskrivelse(taskStepType = TaskStepMedFeil.TYPE, beskrivelse = "Task med feil")
+class TaskStepMedFeil : AsyncTaskStep {
+
+    override fun doTask(task: Task) {
+        error("Feil")
+    }
+
+    companion object {
+
+        const val TYPE = "taskMedFeil"
+    }
+}

--- a/prosessering-jpa/src/test/kotlin/no/nav/familie/prosessering/task/TaskStepMedFeil.kt
+++ b/prosessering-jpa/src/test/kotlin/no/nav/familie/prosessering/task/TaskStepMedFeil.kt
@@ -6,7 +6,8 @@ import no.nav.familie.prosessering.domene.Task
 import org.springframework.stereotype.Service
 
 @Service
-@TaskStepBeskrivelse(taskStepType = TaskStepMedFeil.TYPE, beskrivelse = "Task med feil")
+@TaskStepBeskrivelse(taskStepType = TaskStepMedFeil.TYPE,
+                     beskrivelse = "Task med feil")
 class TaskStepMedFeil : AsyncTaskStep {
 
     override fun doTask(task: Task) {

--- a/prosessering-jpa/src/test/kotlin/no/nav/familie/prosessering/task/TaskStepMedFeilMedTriggerTid0.kt
+++ b/prosessering-jpa/src/test/kotlin/no/nav/familie/prosessering/task/TaskStepMedFeilMedTriggerTid0.kt
@@ -6,20 +6,17 @@ import no.nav.familie.prosessering.domene.Task
 import org.springframework.stereotype.Service
 
 @Service
-@TaskStepBeskrivelse(taskStepType = TaskStepFeilManuellOppfølgning.TASK_FEIL_1,
-                     beskrivelse = "Dette er task 1",
-                     settTilManuellOppfølgning = true,
+@TaskStepBeskrivelse(taskStepType = TaskStepMedFeilMedTriggerTid0.TYPE,
+                     beskrivelse = "Task med feil",
                      triggerTidVedFeilISekunder = 0)
-class TaskStepFeilManuellOppfølgning : AsyncTaskStep {
-
+class TaskStepMedFeilMedTriggerTid0 : AsyncTaskStep {
 
     override fun doTask(task: Task) {
-        error("Feiler")
+        error("Feil")
     }
 
     companion object {
 
-        const val TASK_FEIL_1 = "taskFeilManuellOppfølgning1"
+        const val TYPE = "taskMedFeilMedTriggerTid0"
     }
-
 }

--- a/prosessering-jpa/src/test/resources/application.yaml
+++ b/prosessering-jpa/src/test/resources/application.yaml
@@ -14,6 +14,7 @@ spring:
       ddl-auto: create-drop
     properties:
       hibernate:
+        show_sql: false
         dialect: "org.hibernate.dialect.PostgreSQL95Dialect"
         temp:
           use_jdbc_metadata_defaults: false
@@ -24,3 +25,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+
+prosessering.continuousRunning.enabled: true


### PR DESCRIPTION
…att man har kjørt tasks.

Dette er mulig å skru av hvis man ikke ønsker det.
Pga att taskene rekjøres direkt settes default triggertid til 10s i stedet for 0 som då gjør att de rekjøres direkte

https://nav-it.slack.com/archives/CJN0STWB0/p1632311180087100

Fint hvis dere:
* Sjekker navn på nye configs
* Tar en ekstra titt på feilhåndtering av `executeTasks`