### PR TITLE
Skal kunne hente ut antall tasker som krever oppfølging

### DIFF
--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/ITaskRepostitory.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/ITaskRepostitory.kt
@@ -17,4 +17,6 @@ interface ITaskRepostitory<T : ITask> : PagingAndSortingRepository<T, Long> {
     fun findByStatusIn(status: List<Status>, page: Pageable): List<T>
 
     fun findByStatusAndTriggerTidBefore(status: Status, triggerTid: LocalDateTime): List<T>
+
+    fun countByStatusIn(status: List<Status>): Long
 }

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
@@ -50,4 +50,8 @@ class TaskService(val taskRepository: TaskRepository)  {
         taskRepository.delete(it)
     }
 
+    fun antallTaskerTilOppfølging(): Long {
+        return taskRepository.countByStatusIn(listOf(Status.MANUELL_OPPFØLGING, Status.FEILET))
+    }
+
 }

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/rest/RestTaskService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/rest/RestTaskService.kt
@@ -18,6 +18,18 @@ import java.time.LocalDateTime
 @Service
 class RestTaskService(private val taskService: TaskService) {
 
+    fun finnAntallTaskerSomKreverOppfølging(): Ressurs<Long> {
+        return Result.runCatching {
+            taskService.antallTaskerTilOppfølging()
+        }.fold(
+                onSuccess = { Ressurs.success(it) },
+                onFailure = { e ->
+                    logger.error("Henting av antall tasker som krever oppfølging feilet", e)
+                    Ressurs.failure(errorMessage = "Henting av antall tasker som krever oppfølging feilet.", error = e)
+                }
+        )
+    }
+
     fun hentTasks(statuses: List<Status>, saksbehandlerId: String, page: Int): Ressurs<PaginableResponse<TaskDto>> {
         logger.info("$saksbehandlerId henter tasker med status $statuses")
 

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/rest/TaskController.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/rest/TaskController.kt
@@ -23,6 +23,11 @@ class TaskController(private val restTaskService: RestTaskService, private val o
         return ResponseEntity.ok(restTaskService.hentTasks(statuser, hentBrukernavn(), page ?: 0))
     }
 
+    @GetMapping(path = ["/task/antall-til-oppfolging"])
+    fun antallTilOppfølging(): ResponseEntity<Ressurs<Long>> {
+        return ResponseEntity.ok(restTaskService.finnAntallTaskerSomKreverOppfølging())
+    }
+
     @GetMapping(path = ["/task/logg/{id}"])
     fun tasklogg(@PathVariable id: Long,
                  @RequestParam(required = false) page: Int?): ResponseEntity<Ressurs<List<TaskloggDto>>> {

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerIntegrasjonTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerIntegrasjonTest.kt
@@ -62,5 +62,27 @@ internal class TaskControllerIntegrasjonTest {
         assertThat(repository.findById(avvikshåndtert.id).get().status).isEqualTo(Status.AVVIKSHÅNDTERT)
     }
 
+    @Test
+    fun `skal finne riktig antall tasker for oppfølging`() {
+        val ubehandletTask = Task(type = TaskStep1.TASK_1, payload = "{'a'='b'}", status = Status.UBEHANDLET)
+        val feiletTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.FEILET)
+        val avvikshåndtertTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.AVVIKSHÅNDTERT)
+        val manuellOppfølgingTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.MANUELL_OPPFØLGING)
+        val ferdigTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.FERDIG)
+        val klarTilPlukkTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.KLAR_TIL_PLUKK)
+        repository.save(ubehandletTask)
+        repository.save(feiletTask)
+        repository.save(avvikshåndtertTask)
+        repository.save(manuellOppfølgingTask)
+        repository.save(ferdigTask)
+        repository.save(klarTilPlukkTask)
+
+        val response = taskController.antallTilOppfølging()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body.data).isEqualTo(2)
+    }
+
+
 
 }

--- a/prosessering-jpa/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerIntegrasjonTest.kt
+++ b/prosessering-jpa/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerIntegrasjonTest.kt
@@ -61,5 +61,26 @@ internal class TaskControllerIntegrasjonTest {
         assertThat(repository.findById(avvikshåndtert.id).get().status).isEqualTo(Status.AVVIKSHÅNDTERT)
     }
 
+    @Test
+    fun `skal finne riktig antall tasker for oppfølging`() {
+        val ubehandletTask = Task(type = TaskStep1.TASK_1, payload = "{'a'='b'}", status = Status.UBEHANDLET)
+        val feiletTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.FEILET)
+        val avvikshåndtertTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.AVVIKSHÅNDTERT)
+        val manuellOppfølgingTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.MANUELL_OPPFØLGING)
+        val ferdigTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.FERDIG)
+        val klarTilPlukkTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.KLAR_TIL_PLUKK)
+        repository.save(ubehandletTask)
+        repository.save(feiletTask)
+        repository.save(avvikshåndtertTask)
+        repository.save(manuellOppfølgingTask)
+        repository.save(ferdigTask)
+        repository.save(klarTilPlukkTask)
+
+        val response = taskController.antallTilOppfølging()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body.data).isEqualTo(2)
+    }
+
 
 }


### PR DESCRIPTION
Dette kan vi vise frem på forsiden - og dermed slippe å gå inn på én og én tjeneste for å se om vi må agere. 
`MANUELL_OPPFØLGING` og `FEILET` er statusene som krever oppfølging fra vakt