### PR TITLE
Plukker de eldste taskene klar til prosessering først.

### DIFF
--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/ITaskRepostitory.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/ITaskRepostitory.kt
@@ -8,7 +8,7 @@ import java.time.LocalDateTime
 @NoRepositoryBean
 interface ITaskRepostitory<T : ITask> : PagingAndSortingRepository<T, Long> {
 
-    fun findByStatusInAndTriggerTidBeforeOrderByOpprettetTidDesc(status: List<Status>,
+    fun findByStatusInAndTriggerTidBeforeOrderByOpprettetTid(status: List<Status>,
                                                                  triggerTid: LocalDateTime,
                                                                  page: Pageable): List<T>
 

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
@@ -20,7 +20,7 @@ class TaskService(val taskRepository: TaskRepository)  {
     }
 
     fun finnAlleTasksKlareForProsessering(page: Pageable): List<ITask> {
-        return taskRepository.findByStatusInAndTriggerTidBeforeOrderByOpprettetTidDesc(listOf(Status.KLAR_TIL_PLUKK,
+        return taskRepository.findByStatusInAndTriggerTidBeforeOrderByOpprettetTid(listOf(Status.KLAR_TIL_PLUKK,
                                                                                               Status.UBEHANDLET),
                                                                                        LocalDateTime.now(),
                                                                                        page)

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 
 @Component
-class TaskService(val taskRepository: TaskRepository)  {
+class TaskService(val taskRepository: TaskRepository) {
 
     fun findById(id: Long): ITask {
         return taskRepository.findByIdOrNull(id) ?: error("Task med id: $id ikke funnet.")
@@ -20,10 +20,14 @@ class TaskService(val taskRepository: TaskRepository)  {
     }
 
     fun finnAlleTasksKlareForProsessering(page: Pageable): List<ITask> {
-        return taskRepository.findByStatusInAndTriggerTidBeforeOrderByOpprettetTid(listOf(Status.KLAR_TIL_PLUKK,
-                                                                                              Status.UBEHANDLET),
-                                                                                       LocalDateTime.now(),
-                                                                                       page)
+        return taskRepository.findByStatusInAndTriggerTidBeforeOrderByOpprettetTid(
+            listOf(
+                Status.KLAR_TIL_PLUKK,
+                Status.UBEHANDLET
+            ),
+            LocalDateTime.now(),
+            page
+        )
     }
 
     fun finnAlleFeiledeTasks(): List<ITask> {

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskRepositoryTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskRepositoryTest.kt
@@ -102,6 +102,21 @@ class TaskRepositoryTest {
     }
 
     @Test
+    fun `findByStatusInAndTriggerTidBeforeOrderByOpprettetTid - skal returnere tasks sortert etter opprettet_tid - eldst først`() {
+        val task1 = Task(type = TaskStep1.TASK_1, payload = "task med opprettetTid nå", opprettetTid = LocalDateTime.now())
+        val task2 = Task(type = TaskStep2.TASK_2, payload = "task med tidligst oppprettetTid", opprettetTid = LocalDateTime.now().minusDays(1))
+        val task3 = Task(type = TaskStep2.TASK_2, payload = "task med senest oppettetTid", opprettetTid = LocalDateTime.now().plusDays(1))
+
+        repository.save(task1)
+        repository.save(task2)
+        repository.save(task3)
+
+        val message = repository.findByStatusInAndTriggerTidBeforeOrderByOpprettetTid(listOf(Status.UBEHANDLET), LocalDateTime.now(), PageRequest.of(0, 5))
+
+        assertThat(message.map { it.payload }).containsExactly("task med tidligst oppprettetTid", "task med opprettetTid nå", "task med senest oppettetTid")
+    }
+
+    @Test
     fun `skal håndtere properties`() {
         val property = "PROPERTY"
         val lagretTask = repository.save(Task(type = TaskStep1.TASK_1,

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskRepositoryTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskRepositoryTest.kt
@@ -104,16 +104,29 @@ class TaskRepositoryTest {
     @Test
     fun `findByStatusInAndTriggerTidBeforeOrderByOpprettetTid - skal returnere tasks sortert etter opprettet_tid - eldst først`() {
         val task1 = Task(type = TaskStep1.TASK_1, payload = "task med opprettetTid nå", opprettetTid = LocalDateTime.now())
-        val task2 = Task(type = TaskStep2.TASK_2, payload = "task med tidligst oppprettetTid", opprettetTid = LocalDateTime.now().minusDays(1))
-        val task3 = Task(type = TaskStep2.TASK_2, payload = "task med senest oppettetTid", opprettetTid = LocalDateTime.now().plusDays(1))
+        val task2 = Task(
+            type = TaskStep2.TASK_2,
+            payload = "task med tidligst oppprettetTid",
+            opprettetTid = LocalDateTime.now().minusDays(1)
+        )
+        val task3 =
+            Task(type = TaskStep2.TASK_2, payload = "task med senest oppettetTid", opprettetTid = LocalDateTime.now().plusDays(1))
 
         repository.save(task1)
         repository.save(task2)
         repository.save(task3)
 
-        val message = repository.findByStatusInAndTriggerTidBeforeOrderByOpprettetTid(listOf(Status.UBEHANDLET), LocalDateTime.now(), PageRequest.of(0, 5))
+        val message = repository.findByStatusInAndTriggerTidBeforeOrderByOpprettetTid(
+            listOf(Status.UBEHANDLET),
+            LocalDateTime.now(),
+            PageRequest.of(0, 5)
+        )
 
-        assertThat(message.map { it.payload }).containsExactly("task med tidligst oppprettetTid", "task med opprettetTid nå", "task med senest oppettetTid")
+        assertThat(message.map { it.payload }).containsExactly(
+            "task med tidligst oppprettetTid",
+            "task med opprettetTid nå",
+            "task med senest oppettetTid"
+        )
     }
 
     @Test


### PR DESCRIPTION
Har sett i ba-migrering, et prosjekt med stort antall tasker som opprettes samtidig, at den plukker de aller nyeste taskene først og de taskene som alt var i kø da migreringstaskene blir opprettet, blir tatt til slutt. Noen som kan ta et par timer. Endrer utplukking av tasker som skal prosesseres til å plukke ut de som har blitt opprettet først. 