### PR TITLE
Sletting av tasks uten å hente all tasklogg

### DIFF
--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/DatabaseMaintenance.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/DatabaseMaintenance.kt
@@ -1,0 +1,7 @@
+package no.nav.familie.prosessering.domene
+
+import java.time.LocalDateTime
+
+interface DatabaseMaintenance {
+    fun slettFerdigstilteTasksFørTidspunkt(tidspunkt: LocalDateTime): List<TaskTilSletting>
+}

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/ITaskRepostitory.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/ITaskRepostitory.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.prosessering.domene
 
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.NoRepositoryBean
 import org.springframework.data.repository.PagingAndSortingRepository
@@ -18,8 +17,6 @@ interface ITaskRepostitory<T : ITask> : PagingAndSortingRepository<T, Long> {
     fun findByStatus(status: Status): List<T>
 
     fun findByStatusIn(status: List<Status>, page: Pageable): List<T>
-
-    fun findByStatusAndTriggerTidBefore(status: Status, triggerTid: LocalDateTime, page: Pageable): Page<T>
 
     fun countByStatusIn(status: List<Status>): Long
 

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/TaskTilSletting.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/TaskTilSletting.kt
@@ -1,0 +1,5 @@
+package no.nav.familie.prosessering.domene
+
+import java.time.LocalDateTime
+
+data class TaskTilSletting(val id: Long, val type: String, val callId: String, val triggerTid: LocalDateTime)

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
@@ -4,14 +4,13 @@ import no.nav.familie.prosessering.domene.AntallÅpneTask
 import no.nav.familie.prosessering.domene.ITask
 import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.TaskRepository
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 
 @Component
-class TaskService(val taskRepository: TaskRepository) {
+class TaskService(private val taskRepository: TaskRepository) {
 
     fun findById(id: Long): ITask {
         return taskRepository.findByIdOrNull(id) ?: error("Task med id: $id ikke funnet.")
@@ -42,10 +41,6 @@ class TaskService(val taskRepository: TaskRepository) {
 
     fun finnTasksMedStatus(status: List<Status>, page: Pageable): List<ITask> {
         return taskRepository.findByStatusIn(status, page)
-    }
-
-    fun finnTasksKlarForSletting(eldreEnnDato: LocalDateTime, page: Pageable): Page<ITask> {
-        return taskRepository.findByStatusAndTriggerTidBefore(Status.FERDIG, eldreEnnDato, page)
     }
 
     fun finnTasksTilFrontend(status: List<Status>, page: Pageable, type: String? = null): List<ITask> {

--- a/prosessering-jdbc/pom.xml
+++ b/prosessering-jdbc/pom.xml
@@ -61,7 +61,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
+            <artifactId>spring-boot-test-autoconfigure</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/prosessering-jdbc/pom.xml
+++ b/prosessering-jdbc/pom.xml
@@ -61,7 +61,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-test-autoconfigure</artifactId>
+            <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -75,8 +75,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>1.17.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/prosessering-jdbc/src/main/kotlin/no/nav/familie/prosessering/TaskMetadataConverter.kt
+++ b/prosessering-jdbc/src/main/kotlin/no/nav/familie/prosessering/TaskMetadataConverter.kt
@@ -10,7 +10,7 @@ import org.springframework.data.convert.WritingConverter
 @ReadingConverter
 class StringTilPropertiesWrapperConverter : Converter<String, PropertiesWrapper> {
 
-    override fun convert(p0: String): PropertiesWrapper? {
+    override fun convert(p0: String): PropertiesWrapper {
         return PropertiesWrapper(p0.asProperties())
     }
 }
@@ -18,7 +18,7 @@ class StringTilPropertiesWrapperConverter : Converter<String, PropertiesWrapper>
 @WritingConverter
 class PropertiesWrapperTilStringConverter : Converter<PropertiesWrapper, String> {
 
-    override fun convert(taskPropertiesWrapper: PropertiesWrapper): String? {
+    override fun convert(taskPropertiesWrapper: PropertiesWrapper): String {
         return taskPropertiesWrapper.properties.asString()
     }
 }

--- a/prosessering-jdbc/src/main/kotlin/no/nav/familie/prosessering/domene/DatabaseMaintenanceImpl.kt
+++ b/prosessering-jdbc/src/main/kotlin/no/nav/familie/prosessering/domene/DatabaseMaintenanceImpl.kt
@@ -1,0 +1,34 @@
+package no.nav.familie.prosessering.domene
+
+import no.nav.familie.log.mdc.MDCConstants
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.sql.Timestamp
+import java.time.LocalDateTime
+
+@Service
+class DatabaseMaintenanceImpl(
+    private val jdbcTemplate: JdbcTemplate
+) : DatabaseMaintenance {
+
+    // language=PostgreSQL
+    private val sqlForSletting =
+        """
+        WITH tasks_til_sletting AS (SELECT id FROM task WHERE status = ? AND trigger_tid < ?), 
+        slett_task_logg AS (DELETE FROM task_logg WHERE task_id IN (SELECT id from tasks_til_sletting)) 
+        DELETE FROM task WHERE id IN (SELECT id FROM tasks_til_sletting) RETURNING id, type, metadata, trigger_tid
+        """
+
+    @Transactional
+    override fun slettFerdigstilteTasksFørTidspunkt(tidspunkt: LocalDateTime): List<TaskTilSletting> {
+        return jdbcTemplate.query(sqlForSletting, { rs, _ ->
+            TaskTilSletting(
+                rs.getLong("id"),
+                rs.getString("type"),
+                rs.getString("metadata").asProperties().getProperty(MDCConstants.MDC_CALL_ID),
+                rs.getTimestamp("trigger_tid").toLocalDateTime()
+            )
+        }, Status.FERDIG.name, Timestamp.valueOf(tidspunkt))
+    }
+}

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/DatabaseConfiguration.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/DatabaseConfiguration.kt
@@ -4,6 +4,9 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.jdbc.core.convert.JdbcCustomConversions
 import org.springframework.data.jdbc.repository.config.AbstractJdbcConfiguration
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import javax.sql.DataSource
 
 @Configuration
 class DatabaseConfiguration : AbstractJdbcConfiguration() {
@@ -16,5 +19,10 @@ class DatabaseConfiguration : AbstractJdbcConfiguration() {
                 PropertiesWrapperTilStringConverter()
             )
         )
+    }
+
+    @Bean
+    fun operations(dataSource: DataSource): NamedParameterJdbcOperations {
+        return NamedParameterJdbcTemplate(dataSource)
     }
 }

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/DbContainerInitializer.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/DbContainerInitializer.kt
@@ -1,0 +1,32 @@
+package no.nav.familie.prosessering
+
+import org.springframework.boot.test.util.TestPropertyValues
+import org.springframework.context.ApplicationContextInitializer
+import org.springframework.context.ConfigurableApplicationContext
+import org.testcontainers.containers.PostgreSQLContainer
+
+class DbContainerInitializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    override fun initialize(applicationContext: ConfigurableApplicationContext) {
+        postgres.start()
+        TestPropertyValues.of(
+            "spring.datasource.url=${postgres.jdbcUrl}",
+            "spring.datasource.username=${postgres.username}",
+            "spring.datasource.password=${postgres.password}"
+        ).applyTo(applicationContext.environment)
+    }
+
+    companion object {
+
+        // Lazy because we only want it to be initialized when accessed
+        private val postgres: KPostgreSQLContainer by lazy {
+            KPostgreSQLContainer("postgres:11.1")
+                .withDatabaseName("prosessering")
+                .withUsername("postgres")
+                .withPassword("test")
+        }
+    }
+}
+
+// Hack needed because testcontainers use of generics confuses Kotlin
+class KPostgreSQLContainer(imageName: String) : PostgreSQLContainer<KPostgreSQLContainer>(imageName)

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/IntegrationRunnerTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/IntegrationRunnerTest.kt
@@ -1,0 +1,26 @@
+package no.nav.familie.prosessering
+
+import no.nav.familie.prosessering.domene.TaskRepository
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
+import org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+@ContextConfiguration(classes = [DbContainerInitializer::class, TestAppConfig::class])
+@DataJdbcTest(excludeAutoConfiguration = [TestDatabaseAutoConfiguration::class])
+@EnableAutoConfiguration
+abstract class IntegrationRunnerTest {
+
+    @Autowired
+    private lateinit var repository: TaskRepository
+
+    @AfterEach
+    fun clear() {
+        repository.deleteAll()
+    }
+}

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/domene/DatabaseMaintenanceImplTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/domene/DatabaseMaintenanceImplTest.kt
@@ -1,0 +1,43 @@
+package no.nav.familie.prosessering.domene
+
+import no.nav.familie.prosessering.IntegrationRunnerTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDateTime
+import java.util.UUID
+
+internal class DatabaseMaintenanceImplTest : IntegrationRunnerTest() {
+
+    @Autowired
+    private lateinit var databaseMaintenance: DatabaseMaintenance
+
+    @Autowired
+    private lateinit var taskRepository: TaskRepository
+
+    @Test
+    internal fun `skal slette eldre tasks`() {
+        val etÅrSiden = LocalDateTime.now().minusYears(1)
+        val task1 = taskRepository.save(opprettTask(triggerTid = etÅrSiden))
+        val task2 = taskRepository.save(opprettTask(triggerTid = etÅrSiden))
+
+        val task3 = taskRepository.save(opprettTask(triggerTid = etÅrSiden, status = Status.FEILET))
+        val task4 = taskRepository.save(opprettTask())
+
+        taskRepository.findAll().forEach { println(it) }
+
+        val slettedeTasks = databaseMaintenance.slettFerdigstilteTasksFørTidspunkt(LocalDateTime.now().minusDays(1))
+
+        assertThat(slettedeTasks.map { it.id }).containsExactlyInAnyOrder(task1.id, task2.id)
+        assertThat(taskRepository.findAll().map { it.id }).containsExactlyInAnyOrder(task3.id, task4.id)
+    }
+
+    private fun opprettTask(status: Status = Status.FERDIG, triggerTid: LocalDateTime = LocalDateTime.now()) =
+        Task(
+            type = "type",
+            payload = UUID.randomUUID().toString(),
+            status = status,
+            opprettetTid = triggerTid,
+            triggerTid = triggerTid
+        )
+}

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/AsyncTaskStepTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/AsyncTaskStepTest.kt
@@ -1,20 +1,15 @@
 package no.nav.familie.prosessering.internal
 
 import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.IntegrationRunnerTest
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.aop.framework.AopProxyUtils
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
-import org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration
 import org.springframework.core.annotation.AnnotationUtils
-import org.springframework.test.context.junit.jupiter.SpringExtension
 
-@ExtendWith(SpringExtension::class)
-@DataJdbcTest(excludeAutoConfiguration = [TestDatabaseAutoConfiguration::class])
-class AsyncTaskStepTest {
+class AsyncTaskStepTest : IntegrationRunnerTest() {
 
     @Autowired
     private lateinit var tasker: List<AsyncTaskStep>

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskRepositoryTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskRepositoryTest.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.prosessering.internal
 
-import no.nav.familie.prosessering.TestAppConfig
+import no.nav.familie.prosessering.IntegrationRunnerTest
 import no.nav.familie.prosessering.domene.AntallÅpneTask
 import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
@@ -12,31 +12,18 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.catchThrowable
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
-import org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.test.context.ContextConfiguration
-import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.time.LocalDateTime
 import java.util.Properties
 import java.util.UUID
 
-@ExtendWith(SpringExtension::class)
-@ContextConfiguration(classes = [TestAppConfig::class])
-@DataJdbcTest(excludeAutoConfiguration = [TestDatabaseAutoConfiguration::class])
-class TaskRepositoryTest {
+class TaskRepositoryTest : IntegrationRunnerTest() {
 
     @Autowired
     private lateinit var repository: TaskRepository
-
-    @AfterEach
-    fun clear() {
-        repository.deleteAll()
-    }
 
     @Test
     fun `findByPayloadAndType - skal finne task for gitt payload og type`() {

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskSchedulerTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskSchedulerTest.kt
@@ -1,38 +1,25 @@
 package no.nav.familie.prosessering.internal
 
+import no.nav.familie.prosessering.IntegrationRunnerTest
 import no.nav.familie.prosessering.TaskFeil
-import no.nav.familie.prosessering.TestAppConfig
 import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
-import org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.jdbc.Sql
-import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.time.LocalDateTime
 
-@ExtendWith(SpringExtension::class)
-@ContextConfiguration(classes = [TestAppConfig::class])
-@DataJdbcTest(excludeAutoConfiguration = [TestDatabaseAutoConfiguration::class])
-class TaskSchedulerTest {
+class TaskSchedulerTest : IntegrationRunnerTest() {
 
     @Autowired
     private lateinit var tasksScheduler: TaskScheduler
 
     @Autowired
     private lateinit var taskRepository: TaskRepository
-
-    @AfterEach
-    fun clear() {
-        taskRepository.deleteAll()
-    }
 
     @Test
     @Sql("classpath:sql-testdata/gamle_tasker_med_logg.sql")

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorServiceWithoutRerunTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorServiceWithoutRerunTest.kt
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import no.nav.familie.prosessering.IntegrationRunnerTest
 import no.nav.familie.prosessering.TaskFeil
-import no.nav.familie.prosessering.TestAppConfig
 import no.nav.familie.prosessering.domene.Loggtype
 import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
@@ -19,36 +19,22 @@ import no.nav.familie.prosessering.task.TaskStepMedFeil
 import no.nav.familie.prosessering.task.TaskStepMedFeilMedTriggerTid0
 import no.nav.familie.prosessering.task.TaskStepRekjørSenere
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
-import org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.scheduling.annotation.EnableScheduling
-import org.springframework.test.context.ContextConfiguration
-import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.context.transaction.TestTransaction
 import java.time.LocalDate
 import java.util.UUID
 
 @EnableScheduling
-@ExtendWith(SpringExtension::class)
-@ContextConfiguration(classes = [TestAppConfig::class],)
-@DataJdbcTest(excludeAutoConfiguration = [TestDatabaseAutoConfiguration::class])
-class TaskStepExecutorServiceWithoutRerunTest {
+class TaskStepExecutorServiceWithoutRerunTest : IntegrationRunnerTest() {
 
     @Autowired
     private lateinit var repository: TaskRepository
 
     @Autowired
     private lateinit var taskStepExecutorService: TaskStepExecutorService
-
-    @AfterEach
-    fun clear() {
-        repository.deleteAll()
-    }
 
     @Test
     fun `skal håndtere feil`() {
@@ -118,7 +104,9 @@ class TaskStepExecutorServiceWithoutRerunTest {
 
         val feiletTask = repository.findByIdOrNull(task.id)!!
         assertThat(feiletTask.status).isEqualTo(Status.MANUELL_OPPFØLGING)
-        assertThat(om.readValue<TaskFeil>(feiletTask.logg.last().melding!!).stackTrace).isNotNull
+        feiletTask.logg.filter { it.type == Loggtype.FEILET }
+            .map { om.readValue<TaskFeil>(it.melding!!) }
+            .forEach { assertThat(it.stackTrace).isNotNull }
     }
 
     @Test
@@ -145,7 +133,7 @@ class TaskStepExecutorServiceWithoutRerunTest {
         val oppdatertTask = repository.findByIdOrNull(task.id)!!
 
         assertThat(oppdatertTask.logg).hasSize(3)
-        val melding = om.readValue<TaskFeil>(oppdatertTask.logg.toList()[2].melding!!)
+        val melding = om.readValue<TaskFeil>(oppdatertTask.logg.single { it.type == Loggtype.FEILET }.melding!!)
         assertThat(melding.feilmelding).isEqualTo("feilmelding")
         assertThat(melding.stackTrace).isEqualTo(null)
     }

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskWorkerTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/internal/TaskWorkerTest.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.prosessering.internal
 
-import no.nav.familie.prosessering.TestAppConfig
+import no.nav.familie.prosessering.IntegrationRunnerTest
 import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
@@ -8,30 +8,17 @@ import no.nav.familie.prosessering.task.TaskStep1
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
-import org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.test.context.ContextConfiguration
-import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.context.transaction.TestTransaction
 
-@ExtendWith(SpringExtension::class)
-@ContextConfiguration(classes = [TestAppConfig::class])
-@DataJdbcTest(excludeAutoConfiguration = [TestDatabaseAutoConfiguration::class])
-class TaskWorkerTest {
+class TaskWorkerTest : IntegrationRunnerTest() {
 
     @Autowired
     private lateinit var repository: TaskRepository
 
     @Autowired
     private lateinit var worker: TaskWorker
-
-    @AfterEach
-    fun clear() {
-        repository.deleteAll()
-    }
 
     @Test
     fun `skal behandle task`() {

--- a/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerIntegrasjonTest.kt
+++ b/prosessering-jdbc/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerIntegrasjonTest.kt
@@ -2,7 +2,7 @@ package no.nav.familie.prosessering.rest
 
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.familie.prosessering.TestAppConfig
+import no.nav.familie.prosessering.IntegrationRunnerTest
 import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
@@ -12,18 +12,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
-import org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration
 import org.springframework.http.HttpStatus
-import org.springframework.test.context.ContextConfiguration
-import org.springframework.test.context.junit.jupiter.SpringExtension
 
-@ExtendWith(SpringExtension::class)
-@ContextConfiguration(classes = [TestAppConfig::class])
-@DataJdbcTest(excludeAutoConfiguration = [TestDatabaseAutoConfiguration::class])
-internal class TaskControllerIntegrasjonTest {
+internal class TaskControllerIntegrasjonTest : IntegrationRunnerTest() {
 
     @Autowired
     lateinit var restTaskService: RestTaskService
@@ -32,11 +24,6 @@ internal class TaskControllerIntegrasjonTest {
     lateinit var repository: TaskRepository
 
     lateinit var taskController: TaskController
-
-    @AfterEach
-    fun clear() {
-        repository.deleteAll()
-    }
 
     @BeforeEach
     fun setup() {
@@ -66,7 +53,8 @@ internal class TaskControllerIntegrasjonTest {
         val ubehandletTask = Task(type = TaskStep1.TASK_1, payload = "{'a'='b'}", status = Status.UBEHANDLET)
         val feiletTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.FEILET)
         val avvikshåndtertTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.AVVIKSHÅNDTERT)
-        val manuellOppfølgingTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.MANUELL_OPPFØLGING)
+        val manuellOppfølgingTask =
+            Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.MANUELL_OPPFØLGING)
         val ferdigTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.FERDIG)
         val klarTilPlukkTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.KLAR_TIL_PLUKK)
         repository.save(ubehandletTask)
@@ -87,7 +75,8 @@ internal class TaskControllerIntegrasjonTest {
         val ubehandletTask = Task(type = TaskStep1.TASK_1, payload = "{'a'='b'}", status = Status.UBEHANDLET)
         val feiletTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.FEILET)
         val avvikshåndtertTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.AVVIKSHÅNDTERT)
-        val manuellOppfølgingTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.MANUELL_OPPFØLGING)
+        val manuellOppfølgingTask =
+            Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.MANUELL_OPPFØLGING)
         val ferdigTask = Task(type = TaskStep1.TASK_1, payload = "{'a'='1'}", status = Status.FERDIG)
         val klarTilPlukkTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.KLAR_TIL_PLUKK)
         repository.save(ubehandletTask)

--- a/prosessering-jdbc/src/test/resources/application.yaml
+++ b/prosessering-jdbc/src/test/resources/application.yaml
@@ -10,13 +10,15 @@ spring:
   main:
     allow-bean-definition-overriding: true
     banner-mode: "off"
+    web-application-type: none
   flyway:
     enabled: true
   datasource:
-    username: sa
-    password:
-    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;CASE_INSENSITIVE_IDENTIFIERS=TRUE;MODE=POSTGRESQL
-    driver-class-name: org.h2.Driver
+    #type: com.zaxxer.hikari.HikariDataSource
+    username: postgres
+    password: test
+    url: jdbc:tc:postgresql:11.1:///prosessering
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
 
 
     hikari:
@@ -26,4 +28,3 @@ spring:
       minimum-idle: 1
 
 prosessering.continuousRunning.enabled: true
-prosessering.delete.pagesize: 2


### PR DESCRIPTION
Hade påbegynt på denne når jeg såg at Stig hadde batchet opp sletting av tasks.
Jeg tenker det hadde vært fint hvis vi kunde fjernet disse uten å hente opp tasklogg i minnet

Hadde gjerne sett att vi separterte på Task og TaskLogg, men det tror jeg er en litt større jobb 

❗ ❗ ❗ ❗ ❗ ❗ ❗ ❗ ❗ 
Edit: Måtte bare teste å splitte de. **Splittet Task og TaskLogg**. Har fjernet jdbc-packen for å få litt enklere struktur å ikke forholde meg til abstract klasse for task. Jeg tenkte jeg måtte gjøre det sånn først men tenker vel kanskje nå at det er mulig å unngå det.
❗ Alle tester kjør ikke ennå, men dere ser kanskje prinsippet :) 

**Splitcommit**: https://github.com/navikt/familie-prosessering-backend/commit/c4792dac1b1ff420081dc12aaf9fd07e3c4fed39