### PR TITLE
Splitting av task og tasklogg

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,12 @@
                 <version>3.1.1</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>1.17.2</version>
+                <scope>test</scope>
+            </dependency>
 
         </dependencies>
     </dependencyManagement>

--- a/prosessering-core/pom.xml
+++ b/prosessering-core/pom.xml
@@ -122,6 +122,37 @@
             <artifactId>kotlinx-coroutines-core</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test-autoconfigure</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/TaskLogg.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/TaskLogg.kt
@@ -8,6 +8,7 @@ import java.time.LocalDateTime
 data class TaskLogg(
     @Id
     val id: Long = 0L,
+    val taskId: Long,
     val endretAv: String = BRUKERNAVN_NÅR_SIKKERHETSKONTEKST_IKKE_FINNES,
     val type: Loggtype,
     val node: String = "node1",
@@ -23,3 +24,10 @@ data class TaskLogg(
         const val BRUKERNAVN_NÅR_SIKKERHETSKONTEKST_IKKE_FINNES = "VL"
     }
 }
+
+data class TaskLoggMetadata(
+    val taskId: Long,
+    val antallLogger: Int,
+    val sistOpprettetTid: LocalDateTime?,
+    val sisteKommentar: String?
+)

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/TaskLoggRepository.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/TaskLoggRepository.kt
@@ -1,0 +1,38 @@
+package no.nav.familie.prosessering.domene
+
+import org.springframework.data.jdbc.repository.query.Modifying
+import org.springframework.data.jdbc.repository.query.Query
+import org.springframework.data.repository.PagingAndSortingRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+internal interface TaskLoggRepository : PagingAndSortingRepository<TaskLogg, Long> {
+
+    @Query
+    fun findByTaskId(taskId: Long): List<TaskLogg>
+
+    @Query
+    fun findByTaskIdIn(taskId: List<Long>): List<TaskLogg>
+
+    @Query(
+        """
+        SELECT task_id, count(*) antall_logger, MAX(opprettet_tid) sist_opprettet_tid, 
+            (SELECT melding FROM task_logg tl1 
+              WHERE tl1.task_id = tl.task_id AND type='FEILET' ORDER BY tl1.opprettet_tid DESC LIMIT 1) siste_kommentar
+        FROM task_logg tl
+        WHERE task_id IN (:taskIds)
+        GROUP BY task_id
+    """
+    )
+    fun finnTaskLoggMetadata(taskIds: List<Long>): List<TaskLoggMetadata>
+
+    fun countByTaskIdAndType(taskId: Long, type: Loggtype): Int
+
+    @Modifying
+    @Query("""DELETE FROM task_logg WHERE task_id = :taskId""")
+    fun deleteAllByTaskId(taskId: Long)
+
+    @Modifying
+    @Query("""DELETE FROM task_logg WHERE task_id in (:taskId)""")
+    fun deleteAllByTaskIdIn(taskId: List<Long>)
+}

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskMaintenanceService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskMaintenanceService.kt
@@ -33,7 +33,7 @@ class TaskMaintenanceService(
 
     @Transactional
     fun settPermanentPlukketTilKlarTilPlukk() {
-        val enTimeSiden = LocalDateTime.now().minusMinutes(60)
+        val enTimeSiden = LocalDateTime.now().minusHours(1)
         val (antallPlukkende, tasks) = taskService.finnAllePlukkedeTasks(enTimeSiden)
 
         logger.info("Fant $antallPlukkende tasks som er plukket. ${tasks.size} tasks er plukket minst en time siden")

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
@@ -200,8 +200,8 @@ class TaskService internal constructor(
             taskLoggRepository.save(taskLogg)
             taskRepository.save(task.copy(status = nyStatus))
         } catch (e: IOException) {
-            logger.warn("Feilet lagrering av task=${task.id} med melding. Se secure logs")
-            secureLog.warn("Feilet lagrering av task=${task.id} med melding", e)
+            logger.warn("Feilet lagring av task=${task.id} med melding. Se secure logs")
+            secureLog.warn("Feilet lagring av task=${task.id} med melding", e)
             taskLoggRepository.save(TaskLogg(taskId = task.id, type = Loggtype.FEILET))
             taskRepository.save(task.copy(status = nyStatus))
         }

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
@@ -111,6 +111,13 @@ class TaskService internal constructor(
         return taskRepository.findByPayloadAndType(payload, type)
     }
 
+    /**
+     * Då taskRepository er internal så kan denne fortsatt være fin å bruke fra tests
+     */
+    fun findAll(): Iterable<Task> {
+        return taskRepository.findAll()
+    }
+
     @Transactional
     fun delete(task: Task) {
         taskLoggRepository.deleteAllByTaskId(task.id)

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
@@ -1,24 +1,62 @@
 package no.nav.familie.prosessering.internal
 
+import no.nav.familie.prosessering.TaskFeil
 import no.nav.familie.prosessering.domene.AntallÅpneTask
+import no.nav.familie.prosessering.domene.Avvikstype
+import no.nav.familie.prosessering.domene.Loggtype
 import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.domene.TaskLogg
+import no.nav.familie.prosessering.domene.TaskLoggMetadata
+import no.nav.familie.prosessering.domene.TaskLoggRepository
 import no.nav.familie.prosessering.domene.TaskRepository
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.io.IOException
 import java.time.LocalDateTime
 
 @Component
-class TaskService(val taskRepository: TaskRepository) {
+class TaskService internal constructor(
+    private val taskRepository: TaskRepository,
+    private val taskLoggRepository: TaskLoggRepository
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val secureLog = LoggerFactory.getLogger("secureLogger")
 
     fun findById(id: Long): Task {
         return taskRepository.findByIdOrNull(id) ?: error("Task med id: $id ikke funnet.")
     }
 
+    /**
+     * Brukes for å opprette task
+     */
+    @Transactional
     fun save(task: Task): Task {
-        return taskRepository.save(task)
+        val lagretTask = taskRepository.save(task)
+        validerTask(lagretTask)
+        if (task.versjon == 0L) {
+            taskLoggRepository.save(TaskLogg(type = Loggtype.UBEHANDLET, taskId = lagretTask.id))
+        }
+        return lagretTask
+    }
+
+    /**
+     * Brukes for å opprette flere tasks
+     */
+    @Transactional
+    fun saveAll(tasks: Collection<Task>): List<Task> {
+        return tasks.map { save(it) }
+    }
+
+    private fun validerTask(task: Task) {
+        if ((task.versjon == 0L && task.id != 0L) || (task.id == 0L && task.versjon != 0L)) {
+            error("Når man oppretter en ny task må task og versjon være satte til 0")
+        }
     }
 
     fun finnAlleTasksKlareForProsessering(page: Pageable): List<Task> {
@@ -36,8 +74,9 @@ class TaskService(val taskRepository: TaskRepository) {
         return taskRepository.findByStatus(Status.FEILET)
     }
 
-    fun finnAllePlukkedeTasks(): List<Task> {
-        return taskRepository.findByStatus(Status.PLUKKET)
+    fun finnAllePlukkedeTasks(tid: LocalDateTime): Pair<Long, List<Task>> {
+        return taskRepository.countByStatusIn(listOf(Status.PLUKKET)) to
+            taskRepository.findAllByStatusAndLastProcessed(Status.PLUKKET, tid)
     }
 
     fun finnTasksMedStatus(status: List<Status>, page: Pageable): List<Task> {
@@ -49,19 +88,40 @@ class TaskService(val taskRepository: TaskRepository) {
     }
 
     fun finnTasksTilFrontend(status: List<Status>, page: Pageable, type: String? = null): List<Task> {
-        return if (type == null) taskRepository.findByStatusIn(status, page)
-        else taskRepository.findByStatusInAndType(status, type, page)
+        return if (type == null) {
+            taskRepository.findByStatusIn(status, page)
+        } else {
+            taskRepository.findByStatusInAndType(status, type, page)
+        }
     }
 
     fun finnTasksSomErFerdigNåMenFeiletFør(page: Pageable): List<Task> =
         taskRepository.finnTasksSomErFerdigNåMenFeiletFør(page)
 
+    fun finnTaskLoggMetadata(taskIds: List<Long>): Map<Long, TaskLoggMetadata> {
+        if (taskIds.isEmpty()) return emptyMap()
+        return taskLoggRepository.finnTaskLoggMetadata(taskIds).associateBy { it.taskId }
+    }
+
+    fun findTaskLoggByTaskId(taskId: Long): List<TaskLogg> {
+        return taskLoggRepository.findByTaskId(taskId)
+    }
+
     fun finnTaskMedPayloadOgType(payload: String, type: String): Task? {
         return taskRepository.findByPayloadAndType(payload, type)
     }
 
-    fun delete(it: Task) {
-        taskRepository.delete(it)
+    @Transactional
+    fun delete(task: Task) {
+        taskLoggRepository.deleteAllByTaskId(task.id)
+        taskRepository.delete(task)
+    }
+
+    @Transactional
+    fun deleteAll(tasks: Collection<Task>) {
+        if (tasks.toList().isEmpty()) return
+        taskLoggRepository.deleteAllByTaskIdIn(tasks.map { it.id })
+        taskRepository.deleteAll(tasks)
     }
 
     fun antallTaskerTilOppfølging(): Long {
@@ -70,5 +130,86 @@ class TaskService(val taskRepository: TaskRepository) {
 
     fun tellAntallÅpneTasker(): List<AntallÅpneTask> {
         return taskRepository.countOpenTasks()
+    }
+
+    fun antallFeil(taskId: Long): Int {
+        return taskLoggRepository.countByTaskIdAndType(taskId, Loggtype.FEILET)
+    }
+
+    @Transactional
+    fun avvikshåndter(task: Task, avvikstype: Avvikstype, årsak: String, endretAv: String): Task {
+
+        val taskLogg = TaskLogg(taskId = task.id, type = Loggtype.AVVIKSHÅNDTERT, melding = årsak, endretAv = endretAv)
+        taskLoggRepository.save(taskLogg)
+        return taskRepository.save(task.copy(status = Status.AVVIKSHÅNDTERT, avvikstype = avvikstype))
+    }
+
+    @Transactional
+    fun kommenter(task: Task, kommentar: String, endretAv: String, settTilManuellOppfølgning: Boolean): Task {
+        val taskLogg = TaskLogg(taskId = task.id, type = Loggtype.KOMMENTAR, melding = kommentar, endretAv = endretAv)
+        taskLoggRepository.save(taskLogg)
+        return taskRepository.save(task.copy(status = if (settTilManuellOppfølgning) Status.MANUELL_OPPFØLGING else task.status))
+    }
+
+    @Transactional
+    fun behandler(task: Task): Task {
+        taskLoggRepository.save(TaskLogg(taskId = task.id, type = Loggtype.BEHANDLER))
+        return taskRepository.save(task.copy(status = Status.BEHANDLER))
+    }
+
+    @Transactional
+    fun klarTilPlukk(task: Task, endretAv: String, melding: String? = null): Task {
+        val taskLogg =
+            TaskLogg(taskId = task.id, type = Loggtype.KLAR_TIL_PLUKK, endretAv = endretAv, melding = melding)
+        taskLoggRepository.save(taskLogg)
+        return taskRepository.save(task.copy(status = Status.KLAR_TIL_PLUKK))
+    }
+
+    @Transactional
+    fun plukker(task: Task): Task {
+        taskLoggRepository.save(TaskLogg(taskId = task.id, type = Loggtype.PLUKKET))
+        return taskRepository.save(task.copy(status = Status.PLUKKET))
+    }
+
+    @Transactional
+    fun ferdigstill(task: Task): Task {
+        taskLoggRepository.save(TaskLogg(taskId = task.id, type = Loggtype.FERDIG))
+        return taskRepository.save(task.copy(status = Status.FERDIG))
+    }
+
+    @Transactional
+    fun feilet(
+        task: Task,
+        feil: TaskFeil,
+        tidligereAntallFeil: Int,
+        maxAntallFeil: Int,
+        settTilManuellOppfølgning: Boolean
+    ): Task {
+        val nyStatus = nyFeiletStatus(tidligereAntallFeil, maxAntallFeil, settTilManuellOppfølgning)
+
+        return try {
+            val melding = feil.writeValueAsString()
+            val taskLogg = TaskLogg(taskId = task.id, type = Loggtype.FEILET, melding = melding)
+            taskLoggRepository.save(taskLogg)
+            taskRepository.save(task.copy(status = nyStatus))
+        } catch (e: IOException) {
+            logger.warn("Feilet lagrering av task=${task.id} med melding. Se secure logs")
+            secureLog.warn("Feilet lagrering av task=${task.id} med melding", e)
+            taskLoggRepository.save(TaskLogg(taskId = task.id, type = Loggtype.FEILET))
+            taskRepository.save(task.copy(status = nyStatus))
+        }
+    }
+
+    private fun nyFeiletStatus(
+        tidligereAntallFeil: Int,
+        maxAntallFeil: Int,
+        settTilManuellOppfølgning: Boolean
+    ): Status {
+        val antallFeilendeForsøk = tidligereAntallFeil + 1
+        return when {
+            maxAntallFeil > antallFeilendeForsøk -> Status.KLAR_TIL_PLUKK
+            settTilManuellOppfølgning -> Status.MANUELL_OPPFØLGING
+            else -> Status.FEILET
+        }
     }
 }

--- a/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/DbContainerInitializer.kt
+++ b/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/DbContainerInitializer.kt
@@ -1,0 +1,32 @@
+package no.nav.familie.prosessering
+
+import org.springframework.boot.test.util.TestPropertyValues
+import org.springframework.context.ApplicationContextInitializer
+import org.springframework.context.ConfigurableApplicationContext
+import org.testcontainers.containers.PostgreSQLContainer
+
+class DbContainerInitializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    override fun initialize(applicationContext: ConfigurableApplicationContext) {
+        postgres.start()
+        TestPropertyValues.of(
+            "spring.datasource.url=${postgres.jdbcUrl}",
+            "spring.datasource.username=${postgres.username}",
+            "spring.datasource.password=${postgres.password}"
+        ).applyTo(applicationContext.environment)
+    }
+
+    companion object {
+
+        // Lazy because we only want it to be initialized when accessed
+        private val postgres: KPostgreSQLContainer by lazy {
+            KPostgreSQLContainer("postgres:14.4")
+                .withDatabaseName("prosessering")
+                .withUsername("postgres")
+                .withPassword("test")
+        }
+    }
+}
+
+// Hack needed because testcontainers use of generics confuses Kotlin
+class KPostgreSQLContainer(imageName: String) : PostgreSQLContainer<KPostgreSQLContainer>(imageName)

--- a/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/IntegrationRunnerTest.kt
+++ b/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/IntegrationRunnerTest.kt
@@ -1,0 +1,29 @@
+package no.nav.familie.prosessering
+
+import no.nav.familie.prosessering.domene.TaskLoggRepository
+import no.nav.familie.prosessering.domene.TaskRepository
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
+import org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+@ContextConfiguration(classes = [DbContainerInitializer::class, TestAppConfig::class])
+@DataJdbcTest(excludeAutoConfiguration = [TestDatabaseAutoConfiguration::class])
+abstract class IntegrationRunnerTest {
+
+    @Autowired
+    private lateinit var repository: TaskRepository
+
+    @Autowired
+    private lateinit var taskLoggRepository: TaskLoggRepository
+
+    @AfterEach
+    fun clear() {
+        taskLoggRepository.deleteAll()
+        repository.deleteAll()
+    }
+}

--- a/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/domene/TaskTest.kt
+++ b/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/domene/TaskTest.kt
@@ -19,7 +19,7 @@ internal class TaskTest {
 
     @Test
     internal fun `TaskLogg skal ikke logge melding`() {
-        val taskLogg = TaskLogg(melding = "melding", type = Loggtype.FEILET)
+        val taskLogg = TaskLogg(taskId = 1, melding = "melding", type = Loggtype.FEILET)
             .copy(opprettetTid = tid)
         assertThat(taskLogg.toString())
             .isEqualTo("TaskLogg(id=0, type=FEILET, opprettetTid=2021-01-01T00:00)")

--- a/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/internal/AsyncTaskStepTest.kt
+++ b/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/internal/AsyncTaskStepTest.kt
@@ -1,20 +1,15 @@
 package no.nav.familie.prosessering.internal
 
 import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.IntegrationRunnerTest
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.aop.framework.AopProxyUtils
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
-import org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration
 import org.springframework.core.annotation.AnnotationUtils
-import org.springframework.test.context.junit.jupiter.SpringExtension
 
-@ExtendWith(SpringExtension::class)
-@DataJdbcTest(excludeAutoConfiguration = [TestDatabaseAutoConfiguration::class])
-class AsyncTaskStepTest {
+class AsyncTaskStepTest : IntegrationRunnerTest() {
 
     @Autowired
     private lateinit var tasker: List<AsyncTaskStep>

--- a/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/internal/TaskServiceTest.kt
+++ b/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/internal/TaskServiceTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.prosessering.internal
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.prosessering.domene.Status
+import no.nav.familie.prosessering.domene.TaskLoggRepository
 import no.nav.familie.prosessering.domene.TaskRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -11,7 +12,8 @@ import org.springframework.data.domain.Pageable
 internal class TaskServiceTest {
 
     private val taskRepository = mockk<TaskRepository>()
-    private val service = TaskService(taskRepository)
+    private val taskLoggRepository = mockk<TaskLoggRepository>()
+    private val service = TaskService(taskRepository, taskLoggRepository)
 
     @Test
     fun tomListeGirTomtResultat() {

--- a/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorServiceWithoutRerunTest.kt
+++ b/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorServiceWithoutRerunTest.kt
@@ -5,11 +5,12 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import no.nav.familie.prosessering.IntegrationRunnerTest
 import no.nav.familie.prosessering.TaskFeil
-import no.nav.familie.prosessering.TestAppConfig
 import no.nav.familie.prosessering.domene.Loggtype
 import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.domene.TaskLoggRepository
 import no.nav.familie.prosessering.domene.TaskRepository
 import no.nav.familie.prosessering.task.TaskStep1
 import no.nav.familie.prosessering.task.TaskStep2
@@ -19,40 +20,32 @@ import no.nav.familie.prosessering.task.TaskStepMedFeil
 import no.nav.familie.prosessering.task.TaskStepMedFeilMedTriggerTid0
 import no.nav.familie.prosessering.task.TaskStepRekjørSenere
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
-import org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.scheduling.annotation.EnableScheduling
-import org.springframework.test.context.ContextConfiguration
-import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.context.transaction.TestTransaction
 import java.time.LocalDate
 import java.util.UUID
 
 @EnableScheduling
-@ExtendWith(SpringExtension::class)
-@ContextConfiguration(classes = [TestAppConfig::class],)
-@DataJdbcTest(excludeAutoConfiguration = [TestDatabaseAutoConfiguration::class])
-class TaskStepExecutorServiceWithoutRerunTest {
+class TaskStepExecutorServiceWithoutRerunTest : IntegrationRunnerTest() {
+
+    @Autowired
+    private lateinit var taskService: TaskService
 
     @Autowired
     private lateinit var repository: TaskRepository
 
     @Autowired
-    private lateinit var taskStepExecutorService: TaskStepExecutorService
+    private lateinit var taskLoggRepository: TaskLoggRepository
 
-    @AfterEach
-    fun clear() {
-        repository.deleteAll()
-    }
+    @Autowired
+    private lateinit var taskStepExecutorService: TaskStepExecutorService
 
     @Test
     fun `skal håndtere feil`() {
-        var savedTask = repository.save(Task(TaskStepMedFeil.TYPE, "{'a'='b'}"))
+        var savedTask = taskService.save(Task(TaskStepMedFeil.TYPE, "{'a'='b'}"))
         TestTransaction.flagForCommit()
         TestTransaction.end()
 
@@ -61,13 +54,15 @@ class TaskStepExecutorServiceWithoutRerunTest {
         taskStepExecutorService.pollAndExecute()
 
         savedTask = repository.findById(savedTask.id).orElseThrow()
+        val taskLogg = taskLoggRepository.findByTaskId(savedTask.id).sortedBy { it.opprettetTid }
+
         assertThat(savedTask.status).isEqualTo(Status.KLAR_TIL_PLUKK)
-        assertThat(savedTask.logg.filter { it.type == Loggtype.FEILET }).hasSize(1)
+        assertThat(taskLogg.filter { it.type == Loggtype.FEILET }).hasSize(1)
     }
 
     @Test
     fun `kommer rekjøre tasker som har 0 i triggerTidVedFeilISekunder direkte`() {
-        var savedTask = repository.save(Task(TaskStepMedFeilMedTriggerTid0.TYPE, "{'a'='b'}"))
+        var savedTask = taskService.save(Task(TaskStepMedFeilMedTriggerTid0.TYPE, "{'a'='b'}"))
         TestTransaction.flagForCommit()
         TestTransaction.end()
 
@@ -76,15 +71,17 @@ class TaskStepExecutorServiceWithoutRerunTest {
         taskStepExecutorService.pollAndExecute()
 
         savedTask = repository.findById(savedTask.id).orElseThrow()
+        val taskLogg = taskLoggRepository.findByTaskId(savedTask.id).sortedBy { it.opprettetTid }
+
         assertThat(savedTask.status).isEqualTo(Status.FEILET)
-        assertThat(savedTask.logg.filter { it.type == Loggtype.FEILET }).hasSize(3)
+        assertThat(taskLogg.filter { it.type == Loggtype.FEILET }).hasSize(3)
     }
 
     @Test
     fun `skal håndtere samtidighet`() {
         repeat(100) {
             val task2 = Task(TaskStep2.TASK_2, "{'a'='b'}")
-            repository.save(task2)
+            taskService.save(task2)
         }
         TestTransaction.flagForCommit()
         TestTransaction.end()
@@ -102,28 +99,32 @@ class TaskStepExecutorServiceWithoutRerunTest {
         }
 
         val findAll = repository.findAll()
-        findAll.filter { it.status != Status.FERDIG || it.logg.size > 4 }.forEach {
+        val taskLogg = taskLoggRepository.findByTaskIdIn(findAll.map { it.id }).groupBy { it.taskId }
+
+        findAll.filter { it.status != Status.FERDIG || taskLogg.getValue(it.id).size > 4 }.forEach {
             assertThat(it.status).isEqualTo(Status.FERDIG)
-            assertThat(it.logg.size).isEqualTo(4)
+            assertThat(taskLogg.getValue(it.id)).hasSize(4)
         }
     }
 
     @Test
     fun `settTilManuellOppfølgning=true - skal sette en task til manuell oppfølgning når den feilet 3 ganger`() {
-        val task = repository.save(Task(TaskStepFeilManuellOppfølgning.TASK_FEIL_1, "{'a'='b'}"))
+        val task = taskService.save(Task(TaskStepFeilManuellOppfølgning.TASK_FEIL_1, "{'a'='b'}"))
         TestTransaction.flagForCommit()
         TestTransaction.end()
 
         taskStepExecutorService.pollAndExecute()
 
         val feiletTask = repository.findByIdOrNull(task.id)!!
+        val taskLogg = taskLoggRepository.findByTaskId(task.id).sortedBy { it.opprettetTid }
+
         assertThat(feiletTask.status).isEqualTo(Status.MANUELL_OPPFØLGING)
-        assertThat(om.readValue<TaskFeil>(feiletTask.logg.last().melding!!).stackTrace).isNotNull
+        assertThat(om.readValue<TaskFeil>(taskLogg.last().melding!!).stackTrace).isNotNull
     }
 
     @Test
     internal fun `rekjørSenere - skal rekjøre tasks som kaster RekjørSenereException`() {
-        val task = repository.save(Task(TaskStepRekjørSenere.TYPE, UUID.randomUUID().toString()))
+        val task = taskService.save(Task(TaskStepRekjørSenere.TYPE, UUID.randomUUID().toString()))
         TestTransaction.flagForCommit()
         TestTransaction.end()
 
@@ -136,23 +137,23 @@ class TaskStepExecutorServiceWithoutRerunTest {
 
     @Test
     internal fun `skal ikke lagre stack trace hvis det ikke trengs`() {
-        val task = repository.save(Task(TaskStepExceptionUtenStackTrace.TYPE, UUID.randomUUID().toString()))
+        val task = taskService.save(Task(TaskStepExceptionUtenStackTrace.TYPE, UUID.randomUUID().toString()))
         TestTransaction.flagForCommit()
         TestTransaction.end()
 
         taskStepExecutorService.pollAndExecute()
 
-        val oppdatertTask = repository.findByIdOrNull(task.id)!!
+        val taskLogg = taskLoggRepository.findByTaskId(task.id).sortedBy { it.opprettetTid }
 
-        assertThat(oppdatertTask.logg).hasSize(3)
-        val melding = om.readValue<TaskFeil>(oppdatertTask.logg.toList()[2].melding!!)
+        assertThat(taskLogg).hasSize(3)
+        val melding = om.readValue<TaskFeil>(taskLogg.last().melding!!)
         assertThat(melding.feilmelding).isEqualTo("feilmelding")
         assertThat(melding.stackTrace).isEqualTo(null)
     }
 
     @Test
     internal fun `skal kjøre task 2 direkte når pollAndExecute er ferdig`() {
-        val task = repository.save(Task(TaskStep1.TASK_1, UUID.randomUUID().toString()))
+        val task = taskService.save(Task(TaskStep1.TASK_1, UUID.randomUUID().toString()))
         TestTransaction.flagForCommit()
         TestTransaction.end()
 

--- a/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/internal/TaskWorkerTest.kt
+++ b/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/internal/TaskWorkerTest.kt
@@ -1,48 +1,44 @@
 package no.nav.familie.prosessering.internal
 
-import no.nav.familie.prosessering.TestAppConfig
+import no.nav.familie.prosessering.IntegrationRunnerTest
 import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.domene.TaskLoggRepository
 import no.nav.familie.prosessering.domene.TaskRepository
 import no.nav.familie.prosessering.task.TaskStep1
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
-import org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.test.context.ContextConfiguration
-import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.context.transaction.TestTransaction
 
-@ExtendWith(SpringExtension::class)
-@ContextConfiguration(classes = [TestAppConfig::class])
-@DataJdbcTest(excludeAutoConfiguration = [TestDatabaseAutoConfiguration::class])
-class TaskWorkerTest {
+class TaskWorkerTest : IntegrationRunnerTest() {
+
+    @Autowired
+    private lateinit var taskService: TaskService
 
     @Autowired
     private lateinit var repository: TaskRepository
 
     @Autowired
-    private lateinit var worker: TaskWorker
+    private lateinit var taskLoggRepository: TaskLoggRepository
 
-    @AfterEach
-    fun clear() {
-        repository.deleteAll()
-    }
+    @Autowired
+    private lateinit var worker: TaskWorker
 
     @Test
     fun `skal behandle task`() {
-        val task = Task(TaskStep1.TASK_1, "{'a'='b'}").plukker()
-        val savedTask = repository.save(task)
+        var task = taskService.save(Task(TaskStep1.TASK_1, "{'a'='b'}"))
+        task = taskService.plukker(task)
         assertThat(task.status).isEqualTo(Status.PLUKKET)
         TestTransaction.flagForCommit()
         TestTransaction.end()
-        worker.doActualWork(savedTask.id)
-        val findByIdOrNull = repository.findByIdOrNull(savedTask.id)
+        worker.doActualWork(task.id)
+
+        val findByIdOrNull = repository.findByIdOrNull(task.id)
+        val taskLogg = taskLoggRepository.findByTaskId(task.id).sortedBy { it.opprettetTid }
+
         assertThat(findByIdOrNull?.status).isEqualTo(Status.FERDIG)
-        assertThat(findByIdOrNull?.logg).hasSize(4)
+        assertThat(taskLogg).hasSize(4)
     }
 }

--- a/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerIntegrasjonTest.kt
+++ b/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerIntegrasjonTest.kt
@@ -2,41 +2,31 @@ package no.nav.familie.prosessering.rest
 
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.familie.prosessering.TestAppConfig
+import no.nav.familie.prosessering.IntegrationRunnerTest
 import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
+import no.nav.familie.prosessering.internal.TaskService
 import no.nav.familie.prosessering.task.TaskStep1
 import no.nav.familie.prosessering.task.TaskStep2
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
-import org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration
 import org.springframework.http.HttpStatus
-import org.springframework.test.context.ContextConfiguration
-import org.springframework.test.context.junit.jupiter.SpringExtension
 
-@ExtendWith(SpringExtension::class)
-@ContextConfiguration(classes = [TestAppConfig::class])
-@DataJdbcTest(excludeAutoConfiguration = [TestDatabaseAutoConfiguration::class])
-internal class TaskControllerIntegrasjonTest {
+internal class TaskControllerIntegrasjonTest : IntegrationRunnerTest() {
 
     @Autowired
     lateinit var restTaskService: RestTaskService
 
     @Autowired
+    lateinit var taskService: TaskService
+
+    @Autowired
     lateinit var repository: TaskRepository
 
     lateinit var taskController: TaskController
-
-    @AfterEach
-    fun clear() {
-        repository.deleteAll()
-    }
 
     @BeforeEach
     fun setup() {
@@ -49,9 +39,9 @@ internal class TaskControllerIntegrasjonTest {
         var ubehandletTask = Task(type = TaskStep1.TASK_1, payload = "{'a'='b'}", status = Status.UBEHANDLET)
         var taskSomSkalRekjøres = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.FEILET)
         var avvikshåndtert = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.AVVIKSHÅNDTERT)
-        ubehandletTask = repository.save(ubehandletTask)
-        taskSomSkalRekjøres = repository.save(taskSomSkalRekjøres)
-        avvikshåndtert = repository.save(avvikshåndtert)
+        ubehandletTask = taskService.save(ubehandletTask)
+        taskSomSkalRekjøres = taskService.save(taskSomSkalRekjøres)
+        avvikshåndtert = taskService.save(avvikshåndtert)
 
         val response = taskController.rekjørTasks(Status.FEILET)
 
@@ -66,15 +56,16 @@ internal class TaskControllerIntegrasjonTest {
         val ubehandletTask = Task(type = TaskStep1.TASK_1, payload = "{'a'='b'}", status = Status.UBEHANDLET)
         val feiletTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.FEILET)
         val avvikshåndtertTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.AVVIKSHÅNDTERT)
-        val manuellOppfølgingTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.MANUELL_OPPFØLGING)
+        val manuellOppfølgingTask =
+            Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.MANUELL_OPPFØLGING)
         val ferdigTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.FERDIG)
         val klarTilPlukkTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.KLAR_TIL_PLUKK)
-        repository.save(ubehandletTask)
-        repository.save(feiletTask)
-        repository.save(avvikshåndtertTask)
-        repository.save(manuellOppfølgingTask)
-        repository.save(ferdigTask)
-        repository.save(klarTilPlukkTask)
+        taskService.save(ubehandletTask)
+        taskService.save(feiletTask)
+        taskService.save(avvikshåndtertTask)
+        taskService.save(manuellOppfølgingTask)
+        taskService.save(ferdigTask)
+        taskService.save(klarTilPlukkTask)
 
         val response = taskController.antallTilOppfølging()
 
@@ -87,15 +78,16 @@ internal class TaskControllerIntegrasjonTest {
         val ubehandletTask = Task(type = TaskStep1.TASK_1, payload = "{'a'='b'}", status = Status.UBEHANDLET)
         val feiletTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.FEILET)
         val avvikshåndtertTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.AVVIKSHÅNDTERT)
-        val manuellOppfølgingTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.MANUELL_OPPFØLGING)
+        val manuellOppfølgingTask =
+            Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.MANUELL_OPPFØLGING)
         val ferdigTask = Task(type = TaskStep1.TASK_1, payload = "{'a'='1'}", status = Status.FERDIG)
         val klarTilPlukkTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.KLAR_TIL_PLUKK)
-        repository.save(ubehandletTask)
-        repository.save(feiletTask)
-        repository.save(avvikshåndtertTask)
-        repository.save(manuellOppfølgingTask)
-        repository.save(ferdigTask)
-        repository.save(klarTilPlukkTask)
+        taskService.save(ubehandletTask)
+        taskService.save(feiletTask)
+        taskService.save(avvikshåndtertTask)
+        taskService.save(manuellOppfølgingTask)
+        taskService.save(ferdigTask)
+        taskService.save(klarTilPlukkTask)
 
         val response = taskController.task2(null, null, TaskStep1.TASK_1)
 
@@ -107,7 +99,7 @@ internal class TaskControllerIntegrasjonTest {
     fun `skal hente kommentarer hvis det finnes i logg`() {
         val ubehandletTask = Task(type = TaskStep1.TASK_1, payload = "{'a'='b'}", status = Status.UBEHANDLET)
 
-        val lagretTask = repository.save(ubehandletTask)
+        val lagretTask = taskService.save(ubehandletTask)
 
         taskController.kommenterTask(lagretTask.id, KommentarDTO(false, "dette er en test"))
 
@@ -121,7 +113,7 @@ internal class TaskControllerIntegrasjonTest {
     fun `skal kommentere og sette status til manuell oppfølging`() {
         val ubehandletTask = Task(type = TaskStep1.TASK_1, payload = "{'a'='b'}", status = Status.UBEHANDLET)
 
-        val lagretTask = repository.save(ubehandletTask)
+        val lagretTask = taskService.save(ubehandletTask)
 
         taskController.kommenterTask(lagretTask.id, KommentarDTO(true, "dette er en test"))
 

--- a/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/task/TaskStep1.kt
+++ b/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/task/TaskStep1.kt
@@ -3,13 +3,13 @@ package no.nav.familie.prosessering.task
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
-import no.nav.familie.prosessering.domene.TaskRepository
+import no.nav.familie.prosessering.internal.TaskService
 import org.springframework.stereotype.Service
 import java.util.concurrent.TimeUnit
 
 @Service
 @TaskStepBeskrivelse(taskStepType = TaskStep1.TASK_1, beskrivelse = "Dette er task 1")
-class TaskStep1 constructor(private val taskRepository: TaskRepository) : AsyncTaskStep {
+class TaskStep1 constructor(private val taskService: TaskService) : AsyncTaskStep {
 
     override fun doTask(task: Task) {
         try {
@@ -22,7 +22,7 @@ class TaskStep1 constructor(private val taskRepository: TaskRepository) : AsyncT
     override fun onCompletion(task: Task) {
         val nesteTask =
             Task(TaskStep2.TASK_2, task.payload)
-        taskRepository.save(nesteTask)
+        taskService.save(nesteTask)
     }
 
     companion object {

--- a/prosessering-core/src/test/resources/application.yaml
+++ b/prosessering-core/src/test/resources/application.yaml
@@ -1,8 +1,5 @@
 spring:
   autoconfigure.exclude: org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration
-  h2:
-    console:
-      enabled: true
   data:
     jdbc:
       repositories:
@@ -10,13 +7,14 @@ spring:
   main:
     allow-bean-definition-overriding: true
     banner-mode: "off"
+    web-application-type: none
   flyway:
     enabled: true
   datasource:
-    username: sa
-    password:
-    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;CASE_INSENSITIVE_IDENTIFIERS=TRUE;MODE=POSTGRESQL
-    driver-class-name: org.h2.Driver
+    username: postgres
+    password: test
+    url: jdbc:tc:postgresql:14.4:///prosessering
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
 
 
     hikari:

--- a/prosessering-core/src/test/resources/sql-testdata/gamle_tasker_med_logg.sql
+++ b/prosessering-core/src/test/resources/sql-testdata/gamle_tasker_med_logg.sql
@@ -7,6 +7,15 @@ VALUES (1000002, '1002351', 'KLAR_TIL_PLUKK', '2019-10-24 10:15:44.061', 'hentSa
 INSERT INTO task (id, payload, status, opprettet_tid, type, metadata, trigger_tid, avvikstype, versjon)
 VALUES (1000003, '1002351', 'FERDIG', '2019-10-24 10:15:42.453', 'hentJournalpostIdFraJoarkTask',
         'callId=CallId_1571904940794_1993984421', '2019-10-24 10:15:42.453038', null, 1);
+INSERT INTO task (id, payload, status, opprettet_tid, type, metadata, trigger_tid, avvikstype, versjon)
+VALUES (1000004, '1002351', 'FERDIG', '2019-10-24 10:15:42.453', 'hentJournalpostIdFraJoarkTask',
+        'callId=CallId_1571904940794_1993984421', '2019-10-24 10:15:42.453038', null, 1);
+INSERT INTO task (id, payload, status, opprettet_tid, type, metadata, trigger_tid, avvikstype, versjon)
+VALUES (1000005, '1002351', 'FERDIG', '2019-10-24 10:15:42.453', 'hentJournalpostIdFraJoarkTask',
+        'callId=CallId_1571904940794_1993984421', '2019-10-24 10:15:42.453038', null, 1);
+INSERT INTO task (id, payload, status, opprettet_tid, type, metadata, trigger_tid, avvikstype, versjon)
+VALUES (1000006, '1002351', 'FERDIG', '2019-10-24 10:15:42.453', 'hentJournalpostIdFraJoarkTask',
+        'callId=CallId_1571904940794_1993984421', '2019-10-24 10:15:42.453038', null, 1);
 
 INSERT INTO task_logg (id, task_id, type, node, opprettet_tid, melding, endret_av)
 VALUES (40010, 1000000, 'UBEHANDLET', 'familie-ks-mottak-5fd7d6649b-gnx4j', '2019-10-24 10:38:13.819', null, 'VL');


### PR DESCRIPTION
Denne ble som et utfall av https://github.com/navikt/familie-prosessering-backend/pull/275 der sletting av data ble gjort uten å hente opp tasklogg. Men så innså jeg at det bare var bedre å splitte allt, som jeg tenkt på tidligere og. 

Kan ta en muntlig gjennomgang av denne hvis dere ønsker.

Ønsker å splitte Task og TaskLogg då vi henter opp veldig mye data fra databasen når en task har feilet mange ganger, med all stacktrace til den. 

For å unngå å sjekke 50 filer, så sjekk commit for commit. Første commiten er kun flytting av filer (ingen direkte endringer forutenom abstracta klasser som task/tasklogg)

❗ Denne trenger litt mer testing(unittester + kjøre lokalt med ex ef-sak) før den eventuellt merges. ❗ 

Tenkte dere kanskje ikke var fan av å slå sammen core og jdbc, så tok å prøvde å ikke gjøre det men blir krøll med beans.
Her er en litt enklere diff av hva som er prøvd å gjøre, der jeg ikke flyttet filene til core:
https://github.com/navikt/familie-prosessering-backend/compare/splitting-av-task-og-tasklogg2?expand=1