### PR TITLE
Unngår å tagge og deploye ny versjon viss vi lukkar ein PR utan å merge

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: github.base_ref == 'master'
+        if: github.base_ref == 'master' && github.event.pull_request.merged == true
         run: |
           export GIT_COMMIT_HASH=$(git log -n 1 --pretty=format:'%h')
           export GIT_COMMIT_DATE=$(git log -1 --pretty='%ad' --date=format:'%Y%m%d%H%M%S')
@@ -52,7 +52,7 @@ jobs:
           mvn --settings .m2/maven-settings.xml versions:commit
 
       - name: Deploy to Github Package
-        if: github.base_ref == 'master'
+        if: github.base_ref == 'master' && github.event.pull_request.merged == true
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Oppdaga i dag at vi fekk ein dependabot-PR på ba-sak, som kom etter ein lukka PR her. Når vi lukkar ein PR utan å merge er det dog ikkje særleg poeng i å køyre eit nytt bygg, lage ny versjon og deploye heller.

La derfor på ein kontrollsjekk på dei bitane.

Eigentleg bør vi ikkje da køyre bygg her i det heile tatt, men det var ikkje like rett fram, så let det liggje i denne omgang.

Testa ut her: https://github.com/navikt/familie-bygg-eksperimentering/actions