### PR TITLE
Sletting av tasks henter kun opp taskId og ikke hele tasken

### DIFF
--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/TaskRepository.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/TaskRepository.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.prosessering.domene
 
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jdbc.repository.query.Query
 import org.springframework.data.repository.CrudRepository
@@ -20,7 +19,8 @@ internal interface TaskRepository : PagingAndSortingRepository<Task, Long>, Crud
 
     fun findByStatusIn(status: List<Status>, page: Pageable): List<Task>
 
-    fun findByStatusAndTriggerTidBefore(status: Status, triggerTid: LocalDateTime, page: Pageable): Page<Task>
+    @Query("SELECT id FROM task WHERE status='FERDIG' AND trigger_tid < :triggerTid LIMIT :limit")
+    fun finnTasksTilSletting(triggerTid: LocalDateTime, limit: Int): List<Long>
 
     fun countByStatusIn(status: List<Status>): Long
 

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskMaintenanceService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskMaintenanceService.kt
@@ -47,9 +47,9 @@ class TaskMaintenanceService(
     fun slettTasksKlarForSletting() {
         val eldreEnnDato = LocalDateTime.now().minusWeeks(deleteTasksAfterWeeks)
         while (true) {
-            val antallTassksSomSlettes = taskService.slettTasks(eldreEnnDato, deleteTasksPageSize)
-            logger.info("Slettet $antallTassksSomSlettes tasks som har triggerTid før $eldreEnnDato")
-            if (antallTassksSomSlettes == 0) {
+            val antallTasksSomSlettes = taskService.slettTasks(eldreEnnDato, deleteTasksPageSize)
+            logger.info("Slettet $antallTasksSomSlettes tasks som har triggerTid før $eldreEnnDato")
+            if (antallTasksSomSlettes == 0) {
                 return
             }
         }

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskScheduler.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskScheduler.kt
@@ -54,7 +54,7 @@ class TaskScheduler(private val taskMaintenanceService: TaskMaintenanceService) 
         if (isOptimisticLocking(e)) {
             logger.warn("OptimisticLockingFailureException metode=$metode")
         } else {
-            logger.warn("Feilet metode=$metode. Se secure logs")
+            logger.error("Feilet metode=$metode. Se secure logs")
             secureLog.info("Feilet metode=$metode", e)
         }
     }

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskScheduler.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskScheduler.kt
@@ -54,7 +54,7 @@ class TaskScheduler(private val taskMaintenanceService: TaskMaintenanceService) 
         if (isOptimisticLocking(e)) {
             logger.warn("OptimisticLockingFailureException metode=$metode")
         } else {
-            logger.error("Feilet metode=$metode. Se secure logs")
+            logger.warn("Feilet metode=$metode. Se secure logs")
             secureLog.info("Feilet metode=$metode", e)
         }
     }

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
@@ -93,6 +93,7 @@ class TaskService internal constructor(
         }
     }
 
+    @Transactional
     internal fun slettTasks(eldreEnnDato: LocalDateTime, antall: Int): Int {
         val taskIds = taskRepository.finnTasksTilSletting(eldreEnnDato, antall)
         if (taskIds.isEmpty()) return 0

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
@@ -11,7 +11,6 @@ import no.nav.familie.prosessering.domene.TaskLoggMetadata
 import no.nav.familie.prosessering.domene.TaskLoggRepository
 import no.nav.familie.prosessering.domene.TaskRepository
 import org.slf4j.LoggerFactory
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
@@ -94,8 +93,13 @@ class TaskService internal constructor(
         }
     }
 
-    internal fun finnTasksKlarForSletting(eldreEnnDato: LocalDateTime, page: Pageable): Page<Task> {
-        return taskRepository.findByStatusAndTriggerTidBefore(Status.FERDIG, eldreEnnDato, page)
+    internal fun slettTasks(eldreEnnDato: LocalDateTime, antall: Int): Int {
+        val taskIds = taskRepository.finnTasksTilSletting(eldreEnnDato, antall)
+        if (taskIds.isEmpty()) return 0
+
+        taskLoggRepository.deleteAllByTaskIdIn(taskIds)
+        taskRepository.deleteAllById(taskIds)
+        return taskIds.size
     }
 
     fun finnTasksSomErFerdigNåMenFeiletFør(page: Pageable): List<Task> =

--- a/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/internal/TaskSchedulerTest.kt
+++ b/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/internal/TaskSchedulerTest.kt
@@ -36,13 +36,10 @@ class TaskSchedulerTest : IntegrationRunnerTest() {
         TestTransaction.end()
         tasksScheduler.slettTasksKlarForSletting()
 
-        taskLoggRepository.findAll().filter { it.type == Loggtype.FEILET }.forEach {
-            println(it)
-        }
-
         assertThat(taskRepository.findAll())
             .hasSize(1)
             .extracting("status").containsOnly(Status.KLAR_TIL_PLUKK)
+        assertThat(taskLoggRepository.findAll().map { it.taskId }).containsOnly(1000002)
     }
 
     @Test


### PR DESCRIPTION
Alternativ til dette:
* Sette cascade delete on på task_logg, sånn at når man fjerner tasks, så fjerner også task_logg som jeg egentlige synes er en fin løsning. Då trenger. man ikke å hente opp taskIds, men å slette de direkte.

* Bruke CTE, men er kanskje litt vanskeligere å tolke :) 
```kotlin
@Modifying
    @Query(
        """
            WITH task_slettes AS (
                SELECT id FROM TASK
                WHERE status = 'FERDIG' AND trigger_tid < :triggerTid
                LIMIT :antall
            ),
            sletter_task_logg AS (
                DELETE from task_logg WHERE task_id IN (SELECT id FROM task_slettes)
                       returning task_id
            )
            DELETE from task WHERE id IN (SELECT id FROM task_slettes)
        """,
    )
    fun slettTasks(triggerTid: LocalDateTime, antall: Int): Long
```