### PR TITLE
Ny status på oppgaver uten feilet tasks

### DIFF
--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
@@ -146,6 +146,13 @@ class TaskService internal constructor(
         return taskRepository.countByStatusIn(listOf(Status.MANUELL_OPPFØLGING, Status.FEILET))
     }
 
+    fun antallTaskerMedStatusFeiletOgManuellOppfølging(): TaskerMedStatusFeiletOgManuellOppfølging {
+        return TaskerMedStatusFeiletOgManuellOppfølging(
+            taskRepository.countByStatusIn(listOf(Status.FEILET)),
+            taskRepository.countByStatusIn(listOf(Status.MANUELL_OPPFØLGING)),
+        )
+    }
+
     internal fun tellAntallÅpneTasker(): List<AntallÅpneTask> {
         return taskRepository.countOpenTasks()
     }

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskerMedStatusFeiletOgManuellOppfølging.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskerMedStatusFeiletOgManuellOppfølging.kt
@@ -1,0 +1,2 @@
+package no.nav.familie.prosessering.internal
+data class TaskerMedStatusFeiletOgManuellOppfølging(val antallFeilet: Long, val antallManuellOppfølging: Long)

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/rest/RestTaskService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/rest/RestTaskService.kt
@@ -28,9 +28,8 @@ class RestTaskService(private val taskService: TaskService) {
         )
     }
 
-    fun finnAntallTaskerMedStatusFeiletOgManuellOppfølging(): Ressurs<
-        TaskerMedStatusFeiletOgManuellOppfølging,
-        > {
+    fun finnAntallTaskerMedStatusFeiletOgManuellOppfølging():
+            Ressurs<TaskerMedStatusFeiletOgManuellOppfølging> {
         val errorMelding = "Henting av antall tasker som har feilet eller er som satt til manuell oppføling feilet."
         return Result.runCatching {
             taskService.antallTaskerMedStatusFeiletOgManuellOppfølging()

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/rest/RestTaskService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/rest/RestTaskService.kt
@@ -4,6 +4,7 @@ import no.nav.familie.prosessering.domene.Avvikstype
 import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
+import no.nav.familie.prosessering.internal.TaskerMedStatusFeiletOgManuellOppfølging
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
@@ -23,6 +24,21 @@ class RestTaskService(private val taskService: TaskService) {
             onFailure = { e ->
                 logger.error("Henting av antall tasker som krever oppfølging feilet", e)
                 Ressurs.failure(errorMessage = "Henting av antall tasker som krever oppfølging feilet.", error = e)
+            },
+        )
+    }
+
+    fun finnAntallTaskerMedStatusFeiletOgManuellOppfølging(): Ressurs<
+        TaskerMedStatusFeiletOgManuellOppfølging,
+        > {
+        val errorMelding = "Henting av antall tasker som har feilet eller er som satt til manuell oppføling feilet."
+        return Result.runCatching {
+            taskService.antallTaskerMedStatusFeiletOgManuellOppfølging()
+        }.fold(
+            onSuccess = { Ressurs.success(it) },
+            onFailure = { e ->
+                logger.error(errorMelding, e)
+                Ressurs.failure(errorMessage = errorMelding, error = e)
             },
         )
     }

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/rest/TaskController.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/rest/TaskController.kt
@@ -2,6 +2,7 @@ package no.nav.familie.prosessering.rest
 
 import no.nav.familie.prosessering.config.ProsesseringInfoProvider
 import no.nav.familie.prosessering.domene.Status
+import no.nav.familie.prosessering.internal.TaskerMedStatusFeiletOgManuellOppfølging
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -16,7 +17,10 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api")
 @ProtectedWithClaims(issuer = "azuread")
-class TaskController(private val restTaskService: RestTaskService, private val prosesseringInfoProvider: ProsesseringInfoProvider) {
+class TaskController(
+    private val restTaskService: RestTaskService,
+    private val prosesseringInfoProvider: ProsesseringInfoProvider,
+) {
 
     fun hentBrukernavn(): String {
         return prosesseringInfoProvider.hentBrukernavn()
@@ -39,6 +43,11 @@ class TaskController(private val restTaskService: RestTaskService, private val p
     @GetMapping(path = ["/task/antall-til-oppfolging"])
     fun antallTilOppfølging(): ResponseEntity<Ressurs<Long>> {
         return ResponseEntity.ok(restTaskService.finnAntallTaskerSomKreverOppfølging())
+    }
+
+    @GetMapping(path = ["/task/antall-feilet-og-manuell-oppfolging"])
+    fun antallFeiletOgManuellOppfølging(): ResponseEntity<Ressurs<TaskerMedStatusFeiletOgManuellOppfølging>> {
+        return ResponseEntity.ok(restTaskService.finnAntallTaskerMedStatusFeiletOgManuellOppfølging())
     }
 
     @GetMapping(path = ["/task/logg/{id}"])

--- a/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerIntegrasjonTest.kt
+++ b/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerIntegrasjonTest.kt
@@ -74,6 +74,24 @@ internal class TaskControllerIntegrasjonTest : IntegrationRunnerTest() {
     }
 
     @Test
+    fun `skal finne riktig antall tasker som har feilet og ligger til manuell oppfølging`() {
+        val feiletTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.FEILET)
+        val feiletTask2 = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.FEILET)
+        val feiletTask3 = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.FEILET)
+
+        val manuellOppfølgingTask =
+            Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.MANUELL_OPPFØLGING)
+
+        taskService.saveAll(listOf(feiletTask, feiletTask2, feiletTask3))
+        taskService.save(manuellOppfølgingTask)
+
+        val response = taskController.antallFeiletOgManuellOppfølging()
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.data?.antallFeilet).isEqualTo(3)
+        assertThat(response.body?.data?.antallManuellOppfølging).isEqualTo(1)
+    }
+
+    @Test
     fun `skal hente tasker av angitt type`() {
         val ubehandletTask = Task(type = TaskStep1.TASK_1, payload = "{'a'='b'}", status = Status.UBEHANDLET)
         val feiletTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.FEILET)

--- a/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerIntegrasjonTest.kt
+++ b/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerIntegrasjonTest.kt
@@ -78,10 +78,11 @@ internal class TaskControllerIntegrasjonTest : IntegrationRunnerTest() {
         val feiletTask = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.FEILET)
         val feiletTask2 = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.FEILET)
         val feiletTask3 = Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.FEILET)
-
+        val ubehandletTask = Task(type = TaskStep1.TASK_1, payload = "{'a'='b'}", status = Status.UBEHANDLET)
         val manuellOppfølgingTask =
             Task(type = TaskStep2.TASK_2, payload = "{'a'='1'}", status = Status.MANUELL_OPPFØLGING)
 
+        taskService.save(ubehandletTask)
         taskService.saveAll(listOf(feiletTask, feiletTask2, feiletTask3))
         taskService.save(manuellOppfølgingTask)
 


### PR DESCRIPTION
Ønsker en ny status på oppgaver hvis det ikke finnes tasks som har feilet, men det er noen som er til manuell oppfølging. Dette er for å raskere få oversikt om det finnes feilet tasks.

Hackaton favro: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-15928

frontend: https://github.com/navikt/familie-prosessering/pull/476