### PR TITLE
Fikser bad request ved søk på callId

### DIFF
--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/TaskRepository.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/TaskRepository.kt
@@ -50,7 +50,7 @@ internal interface TaskRepository : PagingAndSortingRepository<Task, Long>, Crud
         """
         SELECT * 
         FROM task t 
-        WHERE t.metadata like concat('%callId=', concat(:callId, '%'))""",
+        WHERE t.metadata like concat('%callId=', concat(:callId::text, '%'))""",
     )
     fun finnTaskerMedCallId(callId: String): List<Task>
 


### PR DESCRIPTION
Ved søk på enkelte callId i enkelte miljø, så får man ERROR: could not determine data type of parameter. Sier i fra til postgres at dette er en text, slik at concat ikke blir gjort om til f.eks int err uuid.
