### PR TITLE
Fikser feil der rekjøring ikke tok hensyn til max antall feil

### DIFF
--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/error/RekjørSenereException.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/error/RekjørSenereException.kt
@@ -4,3 +4,6 @@ import java.time.LocalDateTime
 
 data class RekjørSenereException(val årsak: String, val triggerTid: LocalDateTime) :
     RuntimeException("Rekjører senere - triggerTid=$triggerTid")
+
+data class MaxAntallRekjøringerException(val maxAntallRekjøring: Int) :
+    RuntimeException("Nådd max antall rekjøring - $maxAntallRekjøring")

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
@@ -157,6 +157,10 @@ class TaskService internal constructor(
         return taskLoggRepository.countByTaskIdAndType(taskId, Loggtype.FEILET)
     }
 
+    fun antallGangerPlukket(taskId: Long): Int {
+        return taskLoggRepository.countByTaskIdAndType(taskId, Loggtype.PLUKKET)
+    }
+
     @Transactional
     internal fun avvikshåndter(task: Task, avvikstype: Avvikstype, årsak: String, endretAv: String): Task {
         val taskLogg = TaskLogg(


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-16216

Første del av favro oppgaven.
Dersom man kastet RekjørSenereException så ble dette plukket opp av rekjørSenere metoden som ikke tok hensyn til max antall feil. Dette fører til at man potensielt kjører en task uendelig ganger.