### PR TITLE
Lagt til støtte for å kunne kjøre tasks direkte etter lagring

### DIFF
--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
@@ -29,7 +29,7 @@ class TaskService internal constructor(
     private val taskRepository: TaskRepository,
     private val taskLoggRepository: TaskLoggRepository,
     @Lazy
-    private val taskTransactionSynchronization: TaskTransactionSynchronization
+    private val taskTransactionSynchronization: TaskTransactionSynchronization,
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -43,7 +43,7 @@ class TaskService internal constructor(
      * Oppretter task og trigger kjøring av task etter commit
      */
     @Transactional
-    fun saveAndRun(task: Task): Task {
+    fun saveAndPoll(task: Task): Task {
         TransactionSynchronizationManager.registerSynchronization(taskTransactionSynchronization)
         return save(task)
     }

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorService.kt
@@ -64,6 +64,7 @@ class TaskStepExecutorService(
         if (!enabled) return
         if (!isRunning.compareAndSet(false, true)) {
             log.debug("Kjører allerede")
+            return
         }
 
         try {

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskTransactionSynchronization.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskTransactionSynchronization.kt
@@ -1,0 +1,16 @@
+package no.nav.familie.prosessering.internal
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.support.TransactionSynchronization
+
+@Component
+class TaskTransactionSynchronization(private val taskStepExecutorService: TaskStepExecutorService) :
+    TransactionSynchronization {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+    override fun afterCommit() {
+        logger.debug("Kaller på pollAndExecute")
+        taskStepExecutorService.pollAndExecute()
+    }
+}

--- a/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/internal/TaskServiceIntegrationTest.kt
+++ b/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/internal/TaskServiceIntegrationTest.kt
@@ -1,0 +1,70 @@
+package no.nav.familie.prosessering.internal
+
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import no.nav.familie.prosessering.IntegrationRunnerTest
+import no.nav.familie.prosessering.domene.Status
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.task.TaskStep2
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.transaction.TestTransaction
+
+class TaskServiceIntegrationTest : IntegrationRunnerTest() {
+
+    private lateinit var loggingEvents: List<ILoggingEvent>
+
+    @Autowired
+    lateinit var taskService: TaskService
+
+    private val task = Task(TaskStep2.TASK_2, "{'a'='b'}")
+
+    @BeforeEach
+    fun setUp() {
+        val listAppender = ListAppender<ILoggingEvent>()
+        (LoggerFactory.getLogger(TaskTransactionSynchronization::class.java) as Logger).addAppender(listAppender)
+        listAppender.start()
+        loggingEvents = listAppender.list
+    }
+
+    @Test
+    fun `save skal ikke kjøre task direkte`() {
+        val task = taskService.save(task)
+        TestTransaction.flagForCommit()
+        TestTransaction.end()
+
+        Thread.sleep(2000)
+
+        assertThat(taskService.findById(task.id).status).isEqualTo(Status.UBEHANDLET)
+        assertThat(loggingEvents.filter { it.message == "Kaller på pollAndExecute" }).isEmpty()
+    }
+
+    @Test
+    fun `saveAndRun skal kjøre task direkte`() {
+        val task = taskService.saveAndRun(task)
+        TestTransaction.flagForCommit()
+        TestTransaction.end()
+
+        Thread.sleep(2000)
+
+        assertThat(taskService.findById(task.id).status).isEqualTo(Status.FERDIG)
+        assertThat(loggingEvents.filter { it.message == "Kaller på pollAndExecute" }).hasSize(1)
+    }
+
+    @Test
+    fun `saveAndRun skal kjøre task direkte, og kun en gang per tråd`() {
+        taskService.saveAndRun(task)
+        taskService.saveAndRun(task)
+        TestTransaction.flagForCommit()
+        TestTransaction.end()
+
+        Thread.sleep(500)
+
+        assertThat(taskService.findAll().map { it.status }).containsExactly(Status.FERDIG, Status.FERDIG)
+        assertThat(loggingEvents.filter { it.message == "Kaller på pollAndExecute" }).hasSize(1)
+    }
+}

--- a/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/internal/TaskServiceIntegrationTest.kt
+++ b/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/internal/TaskServiceIntegrationTest.kt
@@ -44,8 +44,8 @@ class TaskServiceIntegrationTest : IntegrationRunnerTest() {
     }
 
     @Test
-    fun `saveAndRun skal kjøre task direkte`() {
-        val task = taskService.saveAndRun(task)
+    fun `saveAndPoll skal polle etter nye tasks direkte`() {
+        val task = taskService.saveAndPoll(task)
         TestTransaction.flagForCommit()
         TestTransaction.end()
 
@@ -56,9 +56,9 @@ class TaskServiceIntegrationTest : IntegrationRunnerTest() {
     }
 
     @Test
-    fun `saveAndRun skal kjøre task direkte, og kun en gang per tråd`() {
-        taskService.saveAndRun(task)
-        taskService.saveAndRun(task)
+    fun `saveAndPoll skal polle etter tasks direkte, og kun en gang per tråd`() {
+        taskService.saveAndPoll(task)
+        taskService.saveAndPoll(task)
         TestTransaction.flagForCommit()
         TestTransaction.end()
 

--- a/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/internal/TaskServiceTest.kt
+++ b/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/internal/TaskServiceTest.kt
@@ -13,7 +13,7 @@ internal class TaskServiceTest {
 
     private val taskRepository = mockk<TaskRepository>()
     private val taskLoggRepository = mockk<TaskLoggRepository>()
-    private val service = TaskService(taskRepository, taskLoggRepository)
+    private val service = TaskService(taskRepository, taskLoggRepository, mockk())
 
     @Test
     fun tomListeGirTomtResultat() {

--- a/prosessering-core/src/test/resources/application.yaml
+++ b/prosessering-core/src/test/resources/application.yaml
@@ -23,4 +23,5 @@ spring:
       max-lifetime: 30000
       minimum-idle: 1
 
-prosessering.continuousRunning.enabled: true
+prosessering:
+  continuousRunning.enabled: true

--- a/prosessering-core/src/test/resources/logback-test.xml
+++ b/prosessering-core/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- override spring base logging pattern -->
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%d [%-5level] [%thread] %logger{5} %replace(- [%X{consumerId}, %X{callId}, %X{userId}] ){'- \[, , \] ',''}- %m%n"/>
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+
+
+    <logger name="no" level="TRACE"/>
+</configuration>


### PR DESCRIPTION
Det har tidligere vært nevnt behov for dette og føler at det hadde vært fint.

Legger til en metode som lagrer og kaller på `pollAndExecute` etter transaction.
Hvis man kaller på `saveAndRun` 2 ganger i en transaction, så blir `pollAndExecute` kjørt 1 gang, og ikke 1 gang per tilfelle man kaller på `pollAndExecute`

Pga circular dependency så ble `TaskTransactionSynchronization` lazy.
```kotlin
@Lazy
private val taskTransactionSynchronization: TaskTransactionSynchronization
```

For å ikke gå i beina på `@Scheduled` så la jeg inn en `AtomicBoolean`.
Planlagt jobb kjører hvert X sekund fra siste planlagte jobb, men den har ikke noe forhold til hvis denne blir kjørt manuellt i mellomtiden.

Den eneste måten som er mulig å trigge selve jobbet manuellt som jeg funnet er noe i stil med
```kotlin
val scheduledTask: ScheduledTask = prosessor.scheduledTasks.single {
        (it.task.runnable as ScheduledMethodRunnable).method.name == "pollAndExecute"
    }
    val declaredField = ScheduledTask::class.java.getDeclaredField("future")
    declaredField.isAccessible = true
    val message = declaredField.get(scheduledTask) as RunnableScheduledFuture<*>
    message.run()
 ```
Mulig det finnes andre måter, men denne valgte jeg å ikke gå for.