### PR TITLE
Mulighet til å sette en task direkte til manuell oppfølging i klientkode

### DIFF
--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
@@ -174,6 +174,14 @@ class TaskService internal constructor(
     }
 
     @Transactional
+    fun settTilManuellOppfølging(task: Task, årsak: String? = null): Task {
+        val taskLogg =
+            TaskLogg(taskId = task.id, type = Loggtype.MANUELL_OPPFØLGING, melding = årsak)
+        taskLoggRepository.save(taskLogg)
+        return taskRepository.save(task.copy(status = Status.MANUELL_OPPFØLGING))
+    }
+
+    @Transactional
     internal fun avvikshåndter(task: Task, avvikstype: Avvikstype, årsak: String, endretAv: String): Task {
         val taskLogg = TaskLogg(
             taskId = task.id,

--- a/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/internal/TaskServiceIntegrationTest.kt
+++ b/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/internal/TaskServiceIntegrationTest.kt
@@ -2,13 +2,15 @@ package no.nav.familie.prosessering.internal
 
 import no.nav.familie.prosessering.IntegrationRunnerTest
 import no.nav.familie.prosessering.TaskFeil
+import no.nav.familie.prosessering.domene.Loggtype
+import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskLoggRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 
-internal class TaskLoggRepositoryTest : IntegrationRunnerTest() {
+internal class TaskServiceIntegrationTest : IntegrationRunnerTest() {
 
     @Autowired
     private lateinit var taskService: TaskService
@@ -17,7 +19,7 @@ internal class TaskLoggRepositoryTest : IntegrationRunnerTest() {
     private lateinit var taskLoggRepository: TaskLoggRepository
 
     @Test
-    internal fun `skal hente metadata til task`() {
+    internal fun `skal lage og hente metadata til task`() {
         var task = taskService.save(Task("minType", "payload"))
         task = taskService.kommenter(task, "kommentar på task", "", false)
         task = taskService.feilet(task, TaskFeil(task, RuntimeException("Feil")), 3, 3, false)
@@ -27,5 +29,18 @@ internal class TaskLoggRepositoryTest : IntegrationRunnerTest() {
         assertThat(taskLoggMetadata.taskId).isEqualTo(task.id)
         assertThat(taskLoggMetadata.antallLogger).isEqualTo(4)
         assertThat(taskLoggMetadata.sisteKommentar).isEqualTo("kommentar på task")
+    }
+
+    @Test
+    internal fun `skal sette task-status til MANUELL_OPPFØLGING og lage nytt logginnslag`() {
+        val task = taskService.save(Task(type = "minType", payload = "payload"))
+        val årsak = "årsak"
+
+        val oppdatertTask = taskService.settTilManuellOppfølging(task = task, årsak = årsak)
+
+        assertThat(oppdatertTask.status).isEqualTo(Status.MANUELL_OPPFØLGING)
+        val taskLogg = taskLoggRepository.findByTaskId(oppdatertTask.id).find { it.type == Loggtype.MANUELL_OPPFØLGING }
+        assertThat(taskLogg).isNotNull()
+        assertThat(taskLogg?.melding).isEqualTo(årsak)
     }
 }

--- a/prosessering-core/src/test/resources/db/migration/V1__schema.sql
+++ b/prosessering-core/src/test/resources/db/migration/V1__schema.sql
@@ -1,24 +1,25 @@
-
-CREATE TABLE IF NOT EXISTS task (
+CREATE TABLE IF NOT EXISTS task
+(
     id            BIGSERIAL PRIMARY KEY,
     payload       VARCHAR                                              NOT NULL,
     status        VARCHAR(20)  DEFAULT 'UBEHANDLET'::CHARACTER VARYING NOT NULL,
     versjon       BIGINT       DEFAULT 0,
     opprettet_tid TIMESTAMP(3) DEFAULT LOCALTIMESTAMP,
-    type          VARCHAR(100)                                         NOT NULL,
+    type          VARCHAR                                              NOT NULL,
     metadata      VARCHAR,
     trigger_tid   TIMESTAMP(3) DEFAULT LOCALTIMESTAMP,
-    avvikstype    VARCHAR(50)
+    avvikstype    VARCHAR
 );
 
 CREATE INDEX IF NOT EXISTS henvendelse_status_idx
     ON task (status);
 
-CREATE TABLE IF NOT EXISTS task_logg (
+CREATE TABLE IF NOT EXISTS task_logg
+(
     id            BIGSERIAL PRIMARY KEY,
     task_id       BIGINT       NOT NULL
         CONSTRAINT henvendelse_logg_henvendelse_id_fkey REFERENCES task,
-    type          VARCHAR(15)  NOT NULL,
+    type          VARCHAR      NOT NULL,
     node          VARCHAR(100) NOT NULL,
     opprettet_tid TIMESTAMP(3) DEFAULT LOCALTIMESTAMP,
     melding       VARCHAR,


### PR DESCRIPTION
I tilfeller der noe har feilet i en task-flyt og det ikke hjelper å rekjøre tasken, ønsker vi å kunne sette tasken direkte til manuell oppfølging. Eksempelvis dersom vi i iverksetting får en feilkvittering fra OS. Da ønsker vi å oppdatere egen tilstand og sette tasken til manuell oppfølging slik at vi fanger opp at noe har feilet. I dette tilfellet vil det ikke utgjøre noen forskjell å rekjøre tasken.

Endrer også på test-schema her fordi det mismatcher med de faktiske schemaene i dp-iverksett og familie-ef-iverksett. Mer spesifikt var type-feltet i task_logg for kort til å støtte Loggtype.MANUELL_OPPFØLGING.