### PR TITLE
Setter triggertid til now når man rekjører alle tasker om morgenen

### DIFF
--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskMaintenanceService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskMaintenanceService.kt
@@ -27,7 +27,7 @@ class TaskMaintenanceService(
         logger.info("Rekjører ${tasks.size} tasks")
 
         tasks.forEach {
-            taskService.klarTilPlukk(it, TaskLogg.BRUKERNAVN_NÅR_SIKKERHETSKONTEKST_IKKE_FINNES)
+            taskService.klarTilPlukk(it.medTriggerTid(LocalDateTime.now()), TaskLogg.BRUKERNAVN_NÅR_SIKKERHETSKONTEKST_IKKE_FINNES)
         }
     }
 


### PR DESCRIPTION
Hvis en task feiler og den får triggertid om kvelden neste dag, så vil tasken bli satt til KLAR_TIL_PLUKK neste morgen. Triggertid beholdes, som kan være neste kveld. Så man ser ikke nødvendigvis at en task feiler.

Setter derfor triggertid til now() når man plukker opp alle feilede tasker, slik at det ikke blir noen "skjulte" tasker.

Testet til å fungere lokalt.
