### PR TITLE
Korrigerer namespace som var feil sån at metrics ikke ble plukket opp

### DIFF
--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/metrics/MetricService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/metrics/MetricService.kt
@@ -1,11 +1,10 @@
-package no.nav.tilleggsstonader.soknad.metrics
+package no.nav.familie.prosessering.metrics
 
 import io.micrometer.core.instrument.Metrics
 import io.micrometer.core.instrument.MultiGauge
 import io.micrometer.core.instrument.Tag
 import io.micrometer.core.instrument.Tags
 import no.nav.familie.prosessering.config.ProsesseringInfoProvider
-import no.nav.familie.prosessering.metrics.TaskMetricRepository
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 


### PR DESCRIPTION
Var en liten feil her
https://github.com/navikt/familie-prosessering-backend/pull/514