### PR TITLE
Rollback skal også håndtere checked exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Prosesseringsmotor for familieområdet.
 
+## Utvikling
+Formatter kode med `mvn antrun:run@ktlint-format`
+
 ## Generellt
 * Oppdater status i task-tabellen til lengde 20: `ALTER TABLE task ALTER COLUMN status VARCHAR(20)  DEFAULT 'UBEHANDLET'::CHARACTER VARYING NOT NULL;`
 

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/config/KotlinTransactional.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/config/KotlinTransactional.kt
@@ -1,0 +1,14 @@
+package no.nav.familie.prosessering.config
+
+import org.springframework.core.annotation.AliasFor
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import kotlin.reflect.KClass
+
+@Transactional
+internal annotation class KotlinTransactional(
+    @get:AliasFor(annotation = Transactional::class, attribute = "rollbackFor")
+    val rollbackFor: Array<KClass<out Throwable>> = [Exception::class],
+    @get:AliasFor(annotation = Transactional::class, attribute = "propagation")
+    val propagation: Propagation = Propagation.REQUIRED,
+)

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskMaintenanceService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskMaintenanceService.kt
@@ -3,12 +3,12 @@ package no.nav.familie.prosessering.internal
 import io.micrometer.core.instrument.Metrics
 import io.micrometer.core.instrument.MultiGauge
 import io.micrometer.core.instrument.Tags
+import no.nav.familie.prosessering.config.KotlinTransactional
 import no.nav.familie.prosessering.domene.TaskLogg
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionTemplate
 import java.time.LocalDateTime
 
@@ -21,7 +21,7 @@ class TaskMaintenanceService(
 ) {
     val antallÅpneTaskGague = MultiGauge.builder("openTasks").register(Metrics.globalRegistry)
 
-    @Transactional
+    @KotlinTransactional
     fun retryFeilendeTask() {
         val tasks = taskService.finnAlleFeiledeTasks()
         logger.info("Rekjører ${tasks.size} tasks")
@@ -31,7 +31,7 @@ class TaskMaintenanceService(
         }
     }
 
-    @Transactional
+    @KotlinTransactional
     fun settPermanentPlukketTilKlarTilPlukk() {
         val enTimeSiden = LocalDateTime.now().minusHours(1)
         val (antallPlukkende, tasks) = taskService.finnAllePlukkedeTasks(enTimeSiden)

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskService.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.prosessering.internal
 
 import no.nav.familie.prosessering.TaskFeil
+import no.nav.familie.prosessering.config.KotlinTransactional
 import no.nav.familie.prosessering.domene.AntallÅpneTask
 import no.nav.familie.prosessering.domene.Avvikstype
 import no.nav.familie.prosessering.domene.Loggtype
@@ -14,7 +15,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
 import java.io.IOException
 import java.time.LocalDateTime
 
@@ -32,7 +32,7 @@ class TaskService internal constructor(
      * Brukes for å opprette task
      */
     @Suppress("unused") // brukes av klienter
-    @Transactional
+    @KotlinTransactional
     fun save(task: Task): Task {
         val lagretTask = taskRepository.save(task)
         validerTask(lagretTask)
@@ -46,7 +46,7 @@ class TaskService internal constructor(
      * Brukes for å opprette flere tasks
      */
     @Suppress("unused") // brukes av klienter
-    @Transactional
+    @KotlinTransactional
     fun saveAll(tasks: Collection<Task>): List<Task> = tasks.map { save(it) }
 
     private fun validerTask(task: Task) {
@@ -88,7 +88,7 @@ class TaskService internal constructor(
             taskRepository.findByStatusInAndType(status, type, page)
         }
 
-    @Transactional
+    @KotlinTransactional
     internal fun slettTasks(
         eldreEnnDato: LocalDateTime,
         antall: Int,
@@ -130,13 +130,13 @@ class TaskService internal constructor(
     @Suppress("unused") // brukes av klienter
     fun findAll(): List<Task> = taskRepository.findAll().toList()
 
-    @Transactional
+    @KotlinTransactional
     fun delete(task: Task) {
         taskLoggRepository.deleteAllByTaskId(task.id)
         taskRepository.delete(task)
     }
 
-    @Transactional
+    @KotlinTransactional
     @Suppress("unused") // brukes av klienter
     fun deleteAll(tasks: Collection<Task>) {
         if (tasks.toList().isEmpty()) return
@@ -158,7 +158,7 @@ class TaskService internal constructor(
 
     fun antallGangerPlukket(taskId: Long): Int = taskLoggRepository.countByTaskIdAndType(taskId, Loggtype.PLUKKET)
 
-    @Transactional
+    @KotlinTransactional
     internal fun avvikshåndter(
         task: Task,
         avvikstype: Avvikstype,
@@ -176,7 +176,7 @@ class TaskService internal constructor(
         return taskRepository.save(task.copy(status = Status.AVVIKSHÅNDTERT, avvikstype = avvikstype))
     }
 
-    @Transactional
+    @KotlinTransactional
     internal fun kommenter(
         task: Task,
         kommentar: String,
@@ -189,13 +189,13 @@ class TaskService internal constructor(
         return taskRepository.save(task.copy(status = if (settTilManuellOppfølgning) Status.MANUELL_OPPFØLGING else task.status))
     }
 
-    @Transactional
+    @KotlinTransactional
     internal fun behandler(task: Task): Task {
         taskLoggRepository.save(TaskLogg(taskId = task.id, type = Loggtype.BEHANDLER))
         return taskRepository.save(task.copy(status = Status.BEHANDLER))
     }
 
-    @Transactional
+    @KotlinTransactional
     internal fun klarTilPlukk(
         task: Task,
         endretAv: String,
@@ -212,19 +212,19 @@ class TaskService internal constructor(
         return taskRepository.save(task.copy(status = Status.KLAR_TIL_PLUKK))
     }
 
-    @Transactional
+    @KotlinTransactional
     internal fun plukker(task: Task): Task {
         taskLoggRepository.save(TaskLogg(taskId = task.id, type = Loggtype.PLUKKET))
         return taskRepository.save(task.copy(status = Status.PLUKKET))
     }
 
-    @Transactional
+    @KotlinTransactional
     internal fun ferdigstill(task: Task): Task {
         taskLoggRepository.save(TaskLogg(taskId = task.id, type = Loggtype.FERDIG))
         return taskRepository.save(task.copy(status = Status.FERDIG))
     }
 
-    @Transactional
+    @KotlinTransactional
     internal fun feilet(
         task: Task,
         feil: TaskFeil,

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskWorker.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskWorker.kt
@@ -5,6 +5,7 @@ import io.micrometer.core.instrument.Metrics
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskFeil
 import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.config.KotlinTransactional
 import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskLogg.Companion.BRUKERNAVN_NÅR_SIKKERHETSKONTEKST_IKKE_FINNES
@@ -15,7 +16,6 @@ import org.springframework.aop.framework.AopProxyUtils
 import org.springframework.core.annotation.AnnotationUtils
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
-import org.springframework.transaction.annotation.Transactional
 
 @Service
 class TaskWorker(
@@ -74,7 +74,7 @@ class TaskWorker(
             }
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @KotlinTransactional(propagation = Propagation.REQUIRES_NEW)
     fun doActualWork(taskId: Long) {
         var task = taskService.findById(taskId)
 
@@ -98,7 +98,7 @@ class TaskWorker(
         finnFullførtteller(task.type).increment()
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @KotlinTransactional(propagation = Propagation.REQUIRES_NEW)
     fun rekjørSenere(
         taskId: Long,
         e: RekjørSenereException,
@@ -141,7 +141,7 @@ class TaskWorker(
         }
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @KotlinTransactional(propagation = Propagation.REQUIRES_NEW)
     fun doFeilhåndtering(
         taskId: Long,
         e: Throwable,
@@ -185,7 +185,7 @@ class TaskWorker(
     private fun finnSettTilManuellOppfølgning(taskType: String): Boolean =
         settTilManuellOppfølgningVedFeil[taskType] ?: error("Ukjent tasktype $taskType")
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @KotlinTransactional(propagation = Propagation.REQUIRES_NEW)
     fun markerPlukket(id: Long): Task? {
         val task = taskService.findById(id)
 

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/rest/RestTaskService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/rest/RestTaskService.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.prosessering.rest
 
+import no.nav.familie.prosessering.config.KotlinTransactional
 import no.nav.familie.prosessering.domene.Avvikstype
 import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
@@ -11,7 +12,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 
 @Service
@@ -138,7 +138,7 @@ class RestTaskService(
             )
     }
 
-    @Transactional
+    @KotlinTransactional
     fun rekjørTask(
         taskId: Long,
         saksbehandlerId: String,
@@ -151,7 +151,7 @@ class RestTaskService(
         return Ressurs.success(data = "")
     }
 
-    @Transactional
+    @KotlinTransactional
     fun rekjørTasks(
         status: Status,
         type: String?,
@@ -174,7 +174,7 @@ class RestTaskService(
             )
     }
 
-    @Transactional
+    @KotlinTransactional
     fun avvikshåndterTask(
         taskId: Long,
         avvikstype: Avvikstype,
@@ -204,7 +204,7 @@ class RestTaskService(
             )
     }
 
-    @Transactional
+    @KotlinTransactional
     fun kommenterTask(
         taskId: Long,
         kommentarDTO: KommentarDTO,

--- a/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/TestAppConfig.kt
+++ b/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/TestAppConfig.kt
@@ -10,7 +10,10 @@ import org.springframework.context.annotation.Primary
 import org.springframework.core.task.TaskExecutor
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories
 import org.springframework.data.jdbc.repository.config.JdbcRepositoryConfigExtension
+import org.springframework.jdbc.datasource.DataSourceTransactionManager
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import org.springframework.transaction.PlatformTransactionManager
+import javax.sql.DataSource
 
 @SpringBootConfiguration
 @EnableJdbcRepositories("no.nav.familie")
@@ -43,4 +46,7 @@ class TestAppConfig : JdbcRepositoryConfigExtension() {
         }
         return taskExecutor1
     }
+
+    @Bean
+    fun transactionManager(dataSource: DataSource): PlatformTransactionManager = DataSourceTransactionManager(dataSource)
 }

--- a/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/config/KotlinTransactionalTest.kt
+++ b/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/config/KotlinTransactionalTest.kt
@@ -1,0 +1,61 @@
+package no.nav.familie.prosessering.config
+
+import no.nav.familie.prosessering.IntegrationRunnerTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import java.io.IOException
+
+class KotlinTransactionalTest : IntegrationRunnerTest() {
+    @Autowired
+    private lateinit var service: KotlinTransactionalTestService
+
+    @Autowired
+    private lateinit var jdbcTemplate: JdbcTemplate
+
+    @BeforeEach
+    fun setUp() {
+        jdbcTemplate.execute("DROP TABLE IF EXISTS TEST_TABLE")
+        jdbcTemplate.execute("CREATE TABLE TEST_TABLE (id SERIAL PRIMARY KEY, data VARCHAR(255))")
+    }
+
+    @Test
+    fun `happy case`() {
+        service.lagre("testverdi")
+
+        assertThat(hentAntallRader()).isEqualTo(1)
+    }
+
+    @Test
+    fun `skal rulle tilbake når checked exception IOException kastes`() {
+        try {
+            service.lagreMedFeil("testverdi")
+        } catch (_: Exception) {
+            // Forventet unntak, ingen handling nødvendig
+        }
+
+        assertThat(hentAntallRader()).isEqualTo(0)
+    }
+
+    private fun hentAntallRader(): Int? = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM TEST_TABLE", Int::class.java)
+}
+
+@Service
+class KotlinTransactionalTestService(
+    private val jdbcTemplate: JdbcTemplate,
+) {
+    @KotlinTransactional(propagation = Propagation.REQUIRES_NEW)
+    fun lagre(data: String) {
+        jdbcTemplate.update("INSERT INTO TEST_TABLE (data) VALUES (?)", data)
+    }
+
+    @KotlinTransactional(propagation = Propagation.REQUIRES_NEW)
+    fun lagreMedFeil(data: String) {
+        jdbcTemplate.update("INSERT INTO TEST_TABLE (data) VALUES (?)", data)
+        throw IOException("Simulert feil")
+    }
+}

--- a/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerTest.kt
+++ b/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerTest.kt
@@ -4,7 +4,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import no.nav.familie.prosessering.domene.Status
-import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.familie.prosessering.task.TaskStep1
 import org.assertj.core.api.Assertions.assertThat
@@ -62,6 +61,8 @@ internal class TaskControllerTest {
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
         assertThat(response.body!!.data).isNull()
-        assertThat(response.body!!.melding).isEqualTo("Rekjøring av tasker med status '${Status.FEILET}' og type '${TaskStep1.TASK_1}' feilet")
+        assertThat(
+            response.body!!.melding,
+        ).isEqualTo("Rekjøring av tasker med status '${Status.FEILET}' og type '${TaskStep1.TASK_1}' feilet")
     }
 }


### PR DESCRIPTION
- Kotlin håndterer alle exceptions som unchecked. Samtidig ruller @Transactional kun tilbake checked exceptions. Sånn at eks IOException ikke ruller tilbake feil.

Man kan havne i situasjonen der man har en metode:
```kotlin
@Transactional
fun johan() {
  lagrerSøknadTilDatabase()
  annenMetodeSomFeiler() // feiler med checked exception
  oppretterOppgave()
}
```
I dette tilfelle vil lagre søknad gå OK, og ikke bli rullet tilbake då `@Transactional` ikke ruller tilbake eks `IOException`
Då får vi ikke opprettet oppgaven og andre ting vi hadde forventet skulle bli opprettet

Også nevnt her https://nav-it.slack.com/archives/C73B9LC86/p1744096571722879