### PR TITLE
Lagt til WithSpan annotering på kjøring av enkel task slik at hver task skal få sin egen trace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,11 @@
                 <artifactId>token-validation-core</artifactId>
                 <version>${nav.security.token.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.opentelemetry.instrumentation</groupId>
+                <artifactId>opentelemetry-instrumentation-annotations</artifactId>
+                <version>2.16.0</version>
+            </dependency>
 
             <!--Test-->
             <dependency>

--- a/prosessering-core/pom.xml
+++ b/prosessering-core/pom.xml
@@ -52,6 +52,10 @@
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-jdbc</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-instrumentation-annotations</artifactId>
+        </dependency>
         <!--Test-->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorService.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskStepExecutorService.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.prosessering.internal
 
+import io.opentelemetry.instrumentation.annotations.WithSpan
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.error.RekjørSenereException
 import no.nav.familie.prosessering.util.MDCConstants
@@ -105,6 +106,7 @@ class TaskStepExecutorService(
         return true
     }
 
+    @WithSpan(inheritContext = false, value = "prosesserTask")
     private fun executeWork(task: Task) {
         val startTidspunkt = System.currentTimeMillis()
         initLogContext(task)

--- a/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerTest.kt
+++ b/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerTest.kt
@@ -4,7 +4,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import no.nav.familie.prosessering.domene.Status
-import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.familie.prosessering.task.TaskStep1
 import org.assertj.core.api.Assertions.assertThat
@@ -62,6 +61,8 @@ internal class TaskControllerTest {
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
         assertThat(response.body!!.data).isNull()
-        assertThat(response.body!!.melding).isEqualTo("Rekjøring av tasker med status '${Status.FEILET}' og type '${TaskStep1.TASK_1}' feilet")
+        assertThat(
+            response.body!!.melding,
+        ).isEqualTo("Rekjøring av tasker med status '${Status.FEILET}' og type '${TaskStep1.TASK_1}' feilet")
     }
 }


### PR DESCRIPTION
Lagt til en annotering WithSpan med inhertiContext satt til false. Da vil tasken/kjøringen få en egen traceId.

Gjort test med dette både med og uten observabilty enablet. Begge lot seg starte opp med de nye avhengighetene
