### PR TITLE
Sjekk triggertid i tillegg til status i sjekken for om en task kan plukkes

### DIFF
--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/Status.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/Status.kt
@@ -9,7 +9,4 @@ enum class Status {
     UBEHANDLET,
     AVVIKSHÅNDTERT,
     MANUELL_OPPFØLGING,
-    ;
-
-    fun kanPlukkes() = listOf(KLAR_TIL_PLUKK, UBEHANDLET).contains(this)
 }

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/Task.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/Task.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.prosessering.domene
 
-import no.nav.familie.prosessering.domene.Status.*
 import no.nav.familie.prosessering.util.IdUtils
 import no.nav.familie.prosessering.util.MDCConstants
 import org.slf4j.MDC
@@ -17,7 +16,7 @@ data class Task(
     @Id
     val id: Long = 0L,
     val payload: String,
-    val status: Status = UBEHANDLET,
+    val status: Status = Status.UBEHANDLET,
     val avvikstype: Avvikstype? = null,
     val opprettetTid: LocalDateTime = LocalDateTime.now(),
     val triggerTid: LocalDateTime = LocalDateTime.now(),
@@ -72,7 +71,7 @@ data class Task(
 
     fun medTriggerTid(triggerTid: LocalDateTime): Task = this.copy(triggerTid = triggerTid)
 
-    fun kanPlukkes(): Boolean = status in setOf(UBEHANDLET, KLAR_TIL_PLUKK) && triggerTid.isBefore(LocalDateTime.now())
+    fun kanPlukkes(): Boolean = status in setOf(Status.UBEHANDLET, Status.KLAR_TIL_PLUKK) && triggerTid.isBefore(LocalDateTime.now())
 
     override fun toString(): String =
         "Task(id=$id, status=$status, opprettetTid=$opprettetTid, triggerTid=$triggerTid, type='$type', versjon=$versjon)"

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/Task.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/domene/Task.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.prosessering.domene
 
+import no.nav.familie.prosessering.domene.Status.*
 import no.nav.familie.prosessering.util.IdUtils
 import no.nav.familie.prosessering.util.MDCConstants
 import org.slf4j.MDC
@@ -16,7 +17,7 @@ data class Task(
     @Id
     val id: Long = 0L,
     val payload: String,
-    val status: Status = Status.UBEHANDLET,
+    val status: Status = UBEHANDLET,
     val avvikstype: Avvikstype? = null,
     val opprettetTid: LocalDateTime = LocalDateTime.now(),
     val triggerTid: LocalDateTime = LocalDateTime.now(),
@@ -70,6 +71,8 @@ data class Task(
         )
 
     fun medTriggerTid(triggerTid: LocalDateTime): Task = this.copy(triggerTid = triggerTid)
+
+    fun kanPlukkes(): Boolean = status in setOf(UBEHANDLET, KLAR_TIL_PLUKK) && triggerTid.isBefore(LocalDateTime.now())
 
     override fun toString(): String =
         "Task(id=$id, status=$status, opprettetTid=$opprettetTid, triggerTid=$triggerTid, type='$type', versjon=$versjon)"

--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskWorker.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskWorker.kt
@@ -189,7 +189,7 @@ class TaskWorker(
     fun markerPlukket(id: Long): Task? {
         val task = taskService.findById(id)
 
-        if (task.status.kanPlukkes()) {
+        if (task.kanPlukkes()) {
             return taskService.plukker(task)
         }
         return null

--- a/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerTest.kt
+++ b/prosessering-core/src/test/kotlin/no/nav/familie/prosessering/rest/TaskControllerTest.kt
@@ -4,7 +4,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import no.nav.familie.prosessering.domene.Status
-import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.familie.prosessering.task.TaskStep1
 import org.assertj.core.api.Assertions.assertThat
@@ -62,6 +61,8 @@ internal class TaskControllerTest {
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
         assertThat(response.body!!.data).isNull()
-        assertThat(response.body!!.melding).isEqualTo("Rekjøring av tasker med status '${Status.FEILET}' og type '${TaskStep1.TASK_1}' feilet")
+        assertThat(
+            response.body!!.melding,
+        ).isEqualTo("Rekjøring av tasker med status '${Status.FEILET}' og type '${TaskStep1.TASK_1}' feilet")
     }
 }


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24623)

I noen tilfeller har vi opplevd at når det kastes en `RekjørSenereException` med triggertid dagen etter, blir allikevel tasken plukket nesten umiddelbart. Problemet skyldes muligens at tasker blir gjort parallelt på flere poder:

1. To pods kaller `finnAlleTasksKlareForProsessering` omtrent samtidig, og får overlapp i returnerte tasker
2. Pod 1 sjekker om tasken kan plukkes, noe den kan, fordi den har status `UBEHANDLET`
3. Tasken kaster en `RekjørSenereException` og får status `KLAR_TIL_PLUKK` med triggertid dagen etter
4. Pod 2 sjekker om tasken kan plukkes, noe den kan, fordi den har status `KLAR_TIL_PLUKK`
5. Tasken kaster en `RekjørSenereException` og får status `KLAR_TIL_PLUKK` med triggertid dagen etter

Pod 2 ville ikke plukket tasken dersom den også hadde sjekket `triggerTid`, så legger til det i sjekken