### PR TITLE
Skru loggmeldinger fra error til warn

### DIFF
--- a/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskWorker.kt
+++ b/prosessering-core/src/main/kotlin/no/nav/familie/prosessering/internal/TaskWorker.kt
@@ -126,7 +126,7 @@ class TaskWorker(
             // lager metrikker på tasks som har feilet max antall ganger.
             if (feiletTask.status == Status.FEILET || feiletTask.status == Status.MANUELL_OPPFØLGING) {
                 finnFeilteller(feiletTask.type).increment()
-                log.error(
+                log.warn(
                     "Task ${feiletTask.id} av type ${feiletTask.type} har feilet/satt til manuell oppfølgning. " +
                         "Sjekk prosessering for detaljer",
                 )
@@ -164,7 +164,7 @@ class TaskWorker(
         // lager metrikker på tasks som har feilet max antall ganger.
         if (task.status == Status.FEILET || task.status == Status.MANUELL_OPPFØLGING) {
             finnFeilteller(task.type).increment()
-            log.error(
+            log.warn(
                 "Task ${task.id} av type ${task.type} har feilet/satt til manuell oppfølgning. " +
                     "Sjekk prosessering for detaljer",
             )


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24621)

Skrur ned logging på feilede tasker fra error til warn for å redusere mengden støy.